### PR TITLE
Make ci error on warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,9 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  RUSTFLAGS: -D warnings
+
 jobs:
 
   fmt:


### PR DESCRIPTION
### What
Make ci error on warnings.

### Why
Make sure beginners like myself don't accidentally commit code that is warning.