### PR TITLE
Make as_u63 public

### DIFF
--- a/stellar_contract_sdk/src/val.rs
+++ b/stellar_contract_sdk/src/val.rs
@@ -42,7 +42,6 @@ declare_tryfrom!(());
 declare_tryfrom!(bool);
 declare_tryfrom!(i32);
 declare_tryfrom!(u32);
-declare_tryfrom!(i64);
 declare_tryfrom!(Object);
 declare_tryfrom!(Symbol);
 declare_tryfrom!(BitSet);
@@ -85,15 +84,6 @@ impl ValType for i32 {
     }
 }
 
-impl ValType for i64 {
-    fn is_val_type(v: Val) -> bool {
-        v.is_u63()
-    }
-    unsafe fn unchecked_from_val(v: Val) -> Self {
-        v.as_u63()
-    }
-}
-
 impl TryFrom<i64> for Val {
     type Error = Status;
 
@@ -101,6 +91,19 @@ impl TryFrom<i64> for Val {
     fn try_from(i: i64) -> Result<Self, Self::Error> {
         if i > 0 {
             Ok(Val::from_u63(i))
+        } else {
+            Err(status::UNKNOWN_ERROR)
+        }
+    }
+}
+
+impl TryFrom<Val> for i64 {
+    type Error = Status;
+
+    #[inline(always)]
+    fn try_from(value: Val) -> Result<Self, Self::Error> {
+        if value.is_u63() {
+            Ok(value.as_u63())
         } else {
             Err(status::UNKNOWN_ERROR)
         }

--- a/stellar_contract_sdk/src/val.rs
+++ b/stellar_contract_sdk/src/val.rs
@@ -42,6 +42,7 @@ declare_tryfrom!(());
 declare_tryfrom!(bool);
 declare_tryfrom!(i32);
 declare_tryfrom!(u32);
+declare_tryfrom!(i64);
 declare_tryfrom!(Object);
 declare_tryfrom!(Symbol);
 declare_tryfrom!(BitSet);
@@ -84,6 +85,15 @@ impl ValType for i32 {
     }
 }
 
+impl ValType for i64 {
+    fn is_val_type(v: Val) -> bool {
+        v.is_u63()
+    }
+    unsafe fn unchecked_from_val(v: Val) -> Self {
+        v.as_u63()
+    }
+}
+
 impl TryFrom<i64> for Val {
     type Error = Status;
 
@@ -91,19 +101,6 @@ impl TryFrom<i64> for Val {
     fn try_from(i: i64) -> Result<Self, Self::Error> {
         if i > 0 {
             Ok(Val::from_u63(i))
-        } else {
-            Err(status::UNKNOWN_ERROR)
-        }
-    }
-}
-
-impl TryFrom<Val> for i64 {
-    type Error = Status;
-
-    #[inline(always)]
-    fn try_from(value: Val) -> Result<Self, Self::Error> {
-        if value.is_u63() {
-            Ok(value.as_u63())
         } else {
             Err(status::UNKNOWN_ERROR)
         }


### PR DESCRIPTION
Make `is_u63` and `as_u63` public.

Also, fixed a bug in `TryFrom<i64> for Val`.

Also, I noticed the logic for checking the validity of a u63 existed in two places, in `TryFrom<i64> for Val` and in `from_u63`, so I made it so it only lives in the TryFrom. I chose the TryFrom because it needs to do the check or error, and so it is simple for from_u63 to wrap that and abort.

We should probably normalize on the From/TryFrom doing the work and the as_ and from_ functions simply wrapping them for the same reason and consistency.