### PR TITLE
Fix the object type on objects created by the MemHost

### DIFF
--- a/stellar_contract_sdk/src/object.rs
+++ b/stellar_contract_sdk/src/object.rs
@@ -68,9 +68,10 @@ impl Object {
     }
 
     #[cfg(not(target_family = "wasm"))]
-    pub(crate) fn from_idx(idx: usize) -> Object {
-        let body = (idx as u64) << 12;
-        (((body >> 12) as usize) == idx).or_abort();
+    pub(crate) fn from_type_and_idx(ty: u8, idx: usize) -> Object {
+        let body_idx = (idx as u64) << 12;
+        (((body_idx >> 12) as usize) == idx).or_abort();
+        let body = ty as u64 | body_idx;
         let v = unsafe { Val::from_body_and_tag(body, TAG_OBJECT) };
         Object(v)
     }

--- a/stellar_contract_sdk/src/testing/mem.rs
+++ b/stellar_contract_sdk/src/testing/mem.rs
@@ -1,6 +1,7 @@
 use core::panic;
 
 use super::MockHost;
+use crate::object::*;
 use crate::{status, Object, OrAbort, Val};
 use im_rc::{HashMap, Vector};
 use num_bigint::BigInt;
@@ -65,6 +66,26 @@ pub enum MemObj {
     Transaction(MemTransaction),
     BigNum(BigInt),
     // ...
+}
+
+impl MemObj {
+    fn object_type(&self) -> u8 {
+        match self {
+            MemObj::Box(_) => OBJ_BOX,
+            MemObj::Map(_) => OBJ_MAP,
+            MemObj::Vec(_) => OBJ_VEC,
+            MemObj::U64(_) => OBJ_U64,
+            MemObj::I64(_) => OBJ_I64,
+            MemObj::Str(_) => OBJ_STRING,
+            MemObj::Blob(_) => OBJ_BINARY,
+            MemObj::LedgerKey(_) => OBJ_LEDGERKEY,
+            MemObj::LedgerVal(_) => OBJ_LEDGERVAL,
+            MemObj::Operation(_) => OBJ_OPERATION,
+            MemObj::OperationResult(_) => OBJ_OPERATION_RESULT,
+            MemObj::Transaction(_) => OBJ_TRANSACTION,
+            MemObj::BigNum(_) => OBJ_BIGNUM,
+        }
+    }
 }
 
 pub struct MemHost {
@@ -383,8 +404,9 @@ impl MemHost {
 
     pub fn put_obj(&mut self, ob: MemObj) -> Object {
         let idx = self.objs.len();
+        let ty = ob.object_type();
         self.objs.push(ob);
-        Object::from_idx(idx)
+        Object::from_type_and_idx(ty, idx)
     }
 
     pub fn get_obj(&self, ob: Object) -> Option<&MemObj> {


### PR DESCRIPTION
### What

Set the object type on objects created by the MemHost.

### Why

If the object type isn't set in the object then contract code can't inspect what type of object the value is.

Need this for the `Val` `is_i64` function being added in #28.