### PR TITLE
Make u64 only objs and not utilize u63

### DIFF
--- a/stellar_contract_sdk/src/val.rs
+++ b/stellar_contract_sdk/src/val.rs
@@ -89,20 +89,12 @@ impl ValType for i32 {
 }
 
 impl ValType for u64 {
-    // TODO: The ValType trait is not particularly efficient for i64 because it
-    // has to perform its checks twice. It might be more efficient if the
-    // ValType's first function returns an Optional<T> where T is a transform
-    // function.
     fn is_val_type(v: Val) -> bool {
-        v.is_u63() || (v.is_object() && v.as_object().is_type(OBJ_U64))
+        v.is_object() && v.as_object().is_type(OBJ_U64)
     }
     unsafe fn unchecked_from_val(v: Val) -> Self {
-        if v.is_u63() {
-            v.as_u63() as u64
-        } else {
-            let o = v.as_object();
-            host::u64::to_u64(o)
-        }
+        let o = v.as_object();
+        host::u64::to_u64(o)
     }
 }
 
@@ -166,11 +158,7 @@ impl From<i64> for Val {
 impl From<u64> for Val {
     #[inline(always)]
     fn from(u: u64) -> Self {
-        if u < (1 << 63) {
-            Val((u as u64) << 1)
-        } else {
-            unsafe { host::u64::from_u64(u).into() }
-        }
+        unsafe { host::u64::from_u64(u).into() }
     }
 }
 

--- a/test_u64/src/lib.rs
+++ b/test_u64/src/lib.rs
@@ -20,13 +20,10 @@ pub fn add(a: Val, b: Val) -> Val {
 #[cfg(test)]
 mod test {
     use super::add;
-    use sdk::testing::mem::{MemHost, MemObj};
-    use sdk::testing::swap_mock_host;
     use sdk::Val;
     use stellar_contract_sdk as sdk;
     extern crate alloc;
     extern crate std;
-    use std::boxed::Box;
 
     #[test]
     fn test_add() {
@@ -46,18 +43,5 @@ mod test {
         let z: u64 = z.try_into().unwrap();
         let expect: u64 = (1u64 << 63) + 10;
         assert_eq!(z, expect);
-    }
-
-    #[test]
-    fn test_add_explicitly_using_u63_and_objs() {
-        let mut host = Box::new(MemHost::new());
-        let one = host.put_obj(MemObj::U64(1));
-        swap_mock_host(host);
-
-        let x: Val = Val::from(10 as u64);
-        let y: Val = one.into();
-        let z: Val = add(x, y);
-        let z: u64 = z.try_into().unwrap();
-        assert_eq!(z, 11);
     }
 }


### PR DESCRIPTION
### What
Make the `u64` type only transmitted across the host `Val` boundary as an `Object`, and not utilize the `u63` type.

### Why
In #30 I added the use of the `u63` type in transmitting `u64` values when they can fit into 63-bits. This seems like a reasonable optimization at the time. This is also what the `i64` type does, which is a problem. The problem is a user could invoke a contract with an `i64` or an `u64`, and the value could be consumed as either on the contract side if the value was positive and fit into 63-bits. This lack of determinism could make it easier to introduce bugs into contracts or into applications calling contracts.

For example, an application developer might test their application with values that fit into 63-bits, and they might call a contract with an argument using the `u64` type. However, the contract might have been written to assume an `i64` input. The application developer might think everything is swell until someday in the future they finally send a value that requires use of all 64-bits. When the `u64` value using all 64-bits is transmitted it would likely cause an abort in the contract because the contract would see that it is a `u64` value and reject converting it into an `i64`.

I don't think the u63 optimization on u64s is worth these types of problems. The u63 optimization can still be used on the i64 type, but a u63 is always a signed value that just happens to be positive.