### PR TITLE
Refer to addresses as AccountID

### DIFF
--- a/examples/liqpool/src/lib.rs
+++ b/examples/liqpool/src/lib.rs
@@ -380,7 +380,7 @@ mod test {
 
     use super::{_deposit, _init, _withdraw};
     use alloc::string::ToString;
-    use sdk::testing::mem::{Address, Asset, MemHost, MemLedgerKey, MemLedgerVal, MemObj};
+    use sdk::testing::mem::{AccountID, Asset, MemHost, MemLedgerKey, MemLedgerVal, MemObj};
     use sdk::testing::swap_mock_host;
     use stellar_contract_sdk as sdk;
     extern crate alloc;
@@ -391,11 +391,11 @@ mod test {
     fn test() {
         let mut host = Box::new(MemHost::new());
 
-        let addr_p = Address("GP".as_bytes().to_vec());
-        let addr_a = Address("GA".as_bytes().to_vec());
-        let addr_b = Address("GB".as_bytes().to_vec());
-        let addr_u1 = Address("GU1".as_bytes().to_vec());
-        let addr_u2 = Address("GU2".as_bytes().to_vec());
+        let addr_p = AccountID("GP".as_bytes().to_vec());
+        let addr_a = AccountID("GA".as_bytes().to_vec());
+        let addr_b = AccountID("GB".as_bytes().to_vec());
+        let addr_u1 = AccountID("GU1".as_bytes().to_vec());
+        let addr_u2 = AccountID("GU2".as_bytes().to_vec());
 
         let asset_p = Asset::Credit {
             code: "P".to_string(),

--- a/sdk/src/testing/mem.rs
+++ b/sdk/src/testing/mem.rs
@@ -7,30 +7,31 @@ use im_rc::{HashMap, Vector};
 use num_bigint::BigInt;
 
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct Address(pub Vec<u8>);
+pub struct AccountID(pub Vec<u8>);
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum Asset {
     Native,
-    Credit { code: String, issuer: Address },
+    Credit { code: String, issuer: AccountID },
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ContractID(u64);
 
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct ContractKey(Address, ContractID);
+pub struct ContractKey(AccountID, ContractID);
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum MemLedgerKey {
-    Account(Address),
-    TrustLine { account: Address, asset: Asset },
+    Account(AccountID),
+    TrustLine { account: AccountID, asset: Asset },
     ContractCode(ContractKey),
     ContractData(ContractKey, Val),
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum MemLedgerVal {
+    AccountID(AccountID),
     Account(i64),
     Asset(Asset),
     TrustLine(i64),
@@ -412,7 +413,7 @@ impl MockHost for MemHost {
 
 impl MemHost {
     pub fn new() -> Self {
-        let contract = ContractKey(Address(Vec::new()), ContractID(0));
+        let contract = ContractKey(AccountID(Vec::new()), ContractID(0));
         let mut context = Vec::new();
         context.push(contract);
         let objs = Vec::new();


### PR DESCRIPTION
### What
Refer to addresses as AccountID, and make it a valid ledger value.

### Why
AccountID is the term we use in the XDR, and account IDs are on their own a valid ledger value independent from being used as a key.