### PR TITLE
Add with_mock_host interface to make assertions / modifications to MockHost types

### DIFF
--- a/examples/liqpool/src/lib.rs
+++ b/examples/liqpool/src/lib.rs
@@ -381,7 +381,7 @@ mod test {
     use super::{_deposit, _init, _withdraw};
     use alloc::string::ToString;
     use sdk::testing::mem::{AccountID, Asset, MemHost, MemLedgerKey, MemLedgerVal, MemObj};
-    use sdk::testing::swap_mock_host;
+    use sdk::testing::{swap_mock_host, with_mock_host};
     use stellar_contract_sdk as sdk;
     extern crate alloc;
     extern crate std;
@@ -443,7 +443,7 @@ mod test {
         host.put_ledger_value(acc_u1_key.clone(), MemLedgerVal::Account(0));
         host.put_ledger_value(acc_u1_tl_a_key.clone(), MemLedgerVal::TrustLine(100_000));
         host.put_ledger_value(acc_u1_tl_b_key.clone(), MemLedgerVal::TrustLine(100_000));
-        host.put_ledger_value(acc_u1_tl_p_key, MemLedgerVal::TrustLine(0));
+        host.put_ledger_value(acc_u1_tl_p_key.clone(), MemLedgerVal::TrustLine(0));
 
         let acc_u2_key = MemLedgerKey::Account(addr_u2.clone());
         let acc_u2_tl_a_key = MemLedgerKey::TrustLine {
@@ -477,6 +477,14 @@ mod test {
             true
         );
         assert_eq!(_deposit(acc_u1_obj, 100_000, 10_000), 31622);
+
+        with_mock_host(|host: &mut MemHost| {
+            assert_eq!(
+                host.get_ledger_value(acc_u1_tl_p_key),
+                Some(MemLedgerVal::TrustLine(31622))
+            );
+        });
+
         assert_eq!(
             _trade_fixed_in(acc_u2_obj, asset_a_obj, 100, asset_b_obj, 1),
             9

--- a/sdk/src/testing.rs
+++ b/sdk/src/testing.rs
@@ -4,5 +4,4 @@ pub mod fs;
 pub(crate) mod host;
 pub mod mem;
 
-pub use host::swap_mock_host;
-pub use host::MockHost;
+pub use host::{swap_mock_host, with_mock_host, MockHost};

--- a/sdk/src/testing/fs.rs
+++ b/sdk/src/testing/fs.rs
@@ -135,6 +135,10 @@ impl MockHost for FsHost {
     fn vec_append(&mut self, v1: Object, v2: Object) -> Object {
         todo!()
     }
+
+    fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
 }
 
 impl FsHost {

--- a/sdk/src/testing/mem.rs
+++ b/sdk/src/testing/mem.rs
@@ -6,22 +6,22 @@ use crate::{status, Object, OrAbort, Val};
 use im_rc::{HashMap, Vector};
 use num_bigint::BigInt;
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct AccountID(pub Vec<u8>);
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum Asset {
     Native,
     Credit { code: String, issuer: AccountID },
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct ContractID(u64);
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct ContractKey(AccountID, ContractID);
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum MemLedgerKey {
     Account(AccountID),
     TrustLine { account: AccountID, asset: Asset },
@@ -29,7 +29,7 @@ pub enum MemLedgerKey {
     ContractData(ContractKey, Val),
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum MemLedgerVal {
     AccountID(AccountID),
     Account(i64),
@@ -38,20 +38,20 @@ pub enum MemLedgerVal {
     ContractData(Val),
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum MemOperation {}
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum MemOperationResult {
     Ok,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum MemTransaction {}
 
 type HostMap = HashMap<Val, Val>;
 type HostVec = Vector<Val>;
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum MemObj {
     Box(Val),
     Map(HostMap),
@@ -408,6 +408,10 @@ impl MockHost for MemHost {
             vv.append(v2);
             vv
         })
+    }
+
+    fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
+        self
     }
 }
 


### PR DESCRIPTION
This adds a new function `with_mock_host` that lets users in tests pass a closure that receives a mutable reference to the current MockHost-implementing type, to allow asserting on its state or otherwise modifying it between steps in the test. If the user requests the wrong MockHost-implementing type, it will panic with an error.