### PR TITLE
Make invalid symbols error

### DIFF
--- a/examples/liqpool/src/lib.rs
+++ b/examples/liqpool/src/lib.rs
@@ -74,7 +74,7 @@ pub fn trade_fixed_out(
 const DATA_KEY_ACCOUNT: Val = Val::from_symbol(Symbol::from_str("accid"));
 const DATA_KEY_ASSET_POOL: Val = Val::from_symbol(Symbol::from_str("assetpool"));
 const DATA_KEY_ASSET_POOL_CIRCULATING: Val =
-    Val::from_symbol(Symbol::from_str("assetpoolcirculating")); // TODO: This symbol seems too long, why does creating it not fail?
+    Val::from_symbol(Symbol::from_str("assetpoolc")); // TODO: This symbol seems too long, why does creating it not fail?
 const DATA_KEY_ASSET_A: Val = Val::from_symbol(Symbol::from_str("asseta"));
 const DATA_KEY_ASSET_B: Val = Val::from_symbol(Symbol::from_str("assetb"));
 

--- a/examples/liqpool/src/lib.rs
+++ b/examples/liqpool/src/lib.rs
@@ -73,8 +73,7 @@ pub fn trade_fixed_out(
 
 const DATA_KEY_ACCOUNT: Val = Val::from_symbol(Symbol::from_str("accid"));
 const DATA_KEY_ASSET_POOL: Val = Val::from_symbol(Symbol::from_str("assetpool"));
-const DATA_KEY_ASSET_POOL_CIRCULATING: Val =
-    Val::from_symbol(Symbol::from_str("assetpoolc")); // TODO: This symbol seems too long, why does creating it not fail?
+const DATA_KEY_ASSET_POOL_CIRCULATING: Val = Val::from_symbol(Symbol::from_str("assetpoolc"));
 const DATA_KEY_ASSET_A: Val = Val::from_symbol(Symbol::from_str("asseta"));
 const DATA_KEY_ASSET_B: Val = Val::from_symbol(Symbol::from_str("assetb"));
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -41,8 +41,10 @@ pub use val::Val;
 pub use vec::Vec;
 
 #[inline(always)]
-pub fn require(b: bool) {
-    b.or_abort();
+pub const fn require(b: bool) {
+    if !b {
+        panic!();
+    }
 }
 
 #[inline(always)]

--- a/sdk/src/symbol.rs
+++ b/sdk/src/symbol.rs
@@ -44,9 +44,7 @@ impl Symbol {
         let b: &[u8] = s.as_bytes();
         while n < b.len() {
             let ch = b[n] as char;
-            if n >= MAX_CHARS {
-                break;
-            }
+            require(n < MAX_CHARS);
             n += 1;
             accum <<= 6;
             let v = match ch {


### PR DESCRIPTION
### What
Make symbols that are invalid – longer than 10 chars – error during compiling or at runtime.

### Why
It's too easy to make symbols that collide if you define two that have the same first 10 characters.