### PR TITLE
Print size of .wasm files when making

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,10 @@ all:
 	cargo build
 	cargo test
 	cargo build --target wasm32-unknown-unknown --release
-	for i in target/wasm32-unknown-unknown/release/*.wasm ; do \
+	cd target/wasm32-unknown-unknown/release/ && \
+	for i in *.wasm ; do \
 		wasm-opt -Oz "$$i" -o "$$i.tmp" && mv "$$i.tmp" "$$i"; \
+		ls -lh "$$i"; \
 	done
 
 clean:


### PR DESCRIPTION
### What
Print size of .wasm files when running `make all`.

### Why
Easier than manually checking size of files after building.