### PR TITLE
Include profile in build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,20 +21,36 @@ jobs:
         include:
           - os: ubuntu-latest
             target: wasm32-unknown-unknown
+            profile: release
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            profile: debug
           - os: macos-latest
             target: x86_64-apple-darwin
+            profile: debug
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
     - run: rustup target add ${{ matrix.target }}
-    - run: cargo build --verbose --target ${{ matrix.target }}
+    - run: cargo build --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }}
 
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: wasm32-unknown-unknown
+            profile: release
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            profile: debug
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            profile: debug
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
-    - run: cargo test --verbose
+    - run: rustup target add ${{ matrix.target }}
+    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,10 +24,10 @@ jobs:
             profile: release
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            profile: debug
+            profile: dev
           - os: macos-latest
             target: x86_64-apple-darwin
-            profile: debug
+            profile: dev
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -40,14 +40,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: wasm32-unknown-unknown
-            profile: release
-          - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            profile: debug
+            profile: dev
           - os: macos-latest
             target: x86_64-apple-darwin
-            profile: debug
+            profile: dev
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,3 +1,5 @@
+name: Rust
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
### What

Include profile in build and use dev builds for builds intended to run tests, and release for wasm.

### Why

So the build matrix is consistent between this repo and the rs-stellar-xdr repo. Dev for test builds since that's how it will be typically run, release for wasm for same reason.

### Known limitations

I have a bit of a limited understanding of best practices for these things on the Rust ecosystem, but can change this if I got it wrong.
