### PR TITLE
Simplify ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,9 +27,6 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             profile: dev
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            profile: dev
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -43,10 +40,7 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            profile: dev
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            profile: dev
+            profile: test
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### What

Remove mac builds. Also fix the profile used for tests.

### Why

According to Rust discord there isn't a ton of value in testing on other platforms unless we use platform specific configs.

### Known limitations

N/A
