### PR TITLE
Use strkey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base32"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,6 +47,7 @@ name = "example_liqpool"
 version = "0.0.0"
 dependencies = [
  "stellar-contract-sdk",
+ "stellar-strkey",
  "stellar-xdr",
 ]
 
@@ -130,9 +137,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellar-strkey"
+version = "0.0.0"
+source = "git+https://github.com/stellar/rs-stellar-strkey#e9bca80eb2dff582e49b2db452ece083dc8ed5ff"
+dependencies = [
+ "base32",
+]
+
+[[package]]
 name = "stellar-xdr"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr#fb4cedc79aa830667360123bab06853ba848f20b"
+source = "git+https://github.com/stellar/rs-stellar-xdr#a2ff409ba70fbe5315391a4bbae8bc784e05ee01"
 dependencies = [
  "base64",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr#5cb081cb8bffdf0dc82b923ec13d2bda0d85a107"
+source = "git+https://github.com/stellar/rs-stellar-xdr#fb4cedc79aa830667360123bab06853ba848f20b"
 dependencies = [
  "base64",
  "byteorder",

--- a/examples/liqpool/Cargo.toml
+++ b/examples/liqpool/Cargo.toml
@@ -11,3 +11,4 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr" }
+stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey" }

--- a/examples/liqpool/src/lib.rs
+++ b/examples/liqpool/src/lib.rs
@@ -328,6 +328,7 @@ mod test {
     use stellar_contract_sdk::testing::mem::{MemHost, MemLedgerKey, MemLedgerVal, MemObj};
     use stellar_contract_sdk::testing::{swap_mock_host, with_mock_host};
     use stellar_contract_sdk::Object;
+    use stellar_strkey::PublicKeyEd25519;
     use stellar_xdr::{AccountId, AlphaNum4, Asset, AssetCode4, PublicKey, Uint256};
     extern crate alloc;
     extern crate std;
@@ -338,11 +339,41 @@ mod test {
         let host = Box::new(MemHost::new());
         let og_host = swap_mock_host(host);
 
-        let addr_p = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([b'P'; 32])));
-        let addr_a = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([b'A'; 32])));
-        let addr_b = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([b'B'; 32])));
-        let addr_u1 = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([b'1'; 32])));
-        let addr_u2 = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([b'2'; 32])));
+        let addr_p = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+            PublicKeyEd25519::from_string(
+                "GB7MK2PAD7E3WVXB5NAS7BBFUJOFS7VDWNSUYBIFMLYCOUJACMZM3A2W",
+            )
+            .unwrap()
+            .0,
+        )));
+        let addr_a = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+            PublicKeyEd25519::from_string(
+                "GB334SNZ6CYBT4KMSKHXUJNSJMC24AKMXMJP43VSINNZTWFDQVGAKFHR",
+            )
+            .unwrap()
+            .0,
+        )));
+        let addr_b = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+            PublicKeyEd25519::from_string(
+                "GBPOZPUZOKLT7DYXRHIJSNN4WCMNHUGA3HK6CZIFVBUSKFZBALLOFDHN",
+            )
+            .unwrap()
+            .0,
+        )));
+        let addr_u1 = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+            PublicKeyEd25519::from_string(
+                "GCZBDF6P5U7V43REXPDV5PKP5BZ6UZ7BTSYLXNZPMTKBWHB2MDWPQBTH",
+            )
+            .unwrap()
+            .0,
+        )));
+        let addr_u2 = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+            PublicKeyEd25519::from_string(
+                "GATZZAXUDODMHD3SCPAFX7YS5X66L4PPJ732L5LJRA2BAMR7K5O7UBLY",
+            )
+            .unwrap()
+            .0,
+        )));
 
         let asset_p = Asset::AssetTypeCreditAlphanum4(AlphaNum4 {
             asset_code: AssetCode4([b'P'; 4]),


### PR DESCRIPTION
### What

Use strkeys in tests.

### Why

To render account IDs in tests as we routinely view them.

### Known limitations

The interface between strkey and xdr is super verbose. To some degree this makes it worse at this point. Will fix this up so it is less verbose, but not in this PR.
