### PR TITLE
Set overflow-checks on for release profiles in examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ panic = "abort"
 
 [profile.release]
 opt-level = "z"
-overflow-checks = false
+overflow-checks = true
 debug = 0
 strip = "symbols"
 debug-assertions = false

--- a/examples/add/Cargo.toml
+++ b/examples/add/Cargo.toml
@@ -8,9 +8,6 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[dependencies]
-stellar-contract-sdk = {path = "../../sdk"}
-
 [profile.dev]
 overflow-checks = true
 panic = "abort"
@@ -22,3 +19,6 @@ debug = 0
 strip = "symbols"
 debug-assertions = false
 panic = "abort"
+
+[dependencies]
+stellar-contract-sdk = {path = "../../sdk"}

--- a/examples/add/Cargo.toml
+++ b/examples/add/Cargo.toml
@@ -10,3 +10,15 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}
+
+[profile.dev]
+overflow-checks = true
+panic = "abort"
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"

--- a/examples/liqpool/Cargo.toml
+++ b/examples/liqpool/Cargo.toml
@@ -8,6 +8,19 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[profile.dev]
+overflow-checks = true
+panic = "abort"
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+
+
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr" }

--- a/examples/liqpool/Cargo.toml
+++ b/examples/liqpool/Cargo.toml
@@ -20,7 +20,6 @@ strip = "symbols"
 debug-assertions = false
 panic = "abort"
 
-
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr" }

--- a/examples/token/Cargo.toml
+++ b/examples/token/Cargo.toml
@@ -8,5 +8,18 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[profile.dev]
+overflow-checks = true
+panic = "abort"
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+
+
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}

--- a/examples/token/Cargo.toml
+++ b/examples/token/Cargo.toml
@@ -20,6 +20,5 @@ strip = "symbols"
 debug-assertions = false
 panic = "abort"
 
-
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}


### PR DESCRIPTION
### What

Set overflow-checks on for release profiles in examples.

### Why

In other contract ecosystems, like Ethereum, "SafeMath" commonly runs in production/release. We should encourage similar.

Close #62 

### Known limitations

There's a larger issue of sometimes you want checks and sometimes you don't. Maybe we should encourage being explicit with the appropriate functions instead of relying on the configured profile.
