### PR TITLE
Remove build profiles from sub crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ panic = "abort"
 
 [profile.release]
 opt-level = "z"
-overflow-checks = false
+overflow-checks = true
 debug = 0
 strip = "symbols"
 debug-assertions = false

--- a/examples/add/Cargo.toml
+++ b/examples/add/Cargo.toml
@@ -8,17 +8,5 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.dev]
-overflow-checks = true
-panic = "abort"
-
-[profile.release]
-opt-level = "z"
-overflow-checks = true
-debug = 0
-strip = "symbols"
-debug-assertions = false
-panic = "abort"
-
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}

--- a/examples/add/Cargo.toml
+++ b/examples/add/Cargo.toml
@@ -8,9 +8,6 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[dependencies]
-stellar-contract-sdk = {path = "../../sdk"}
-
 [profile.dev]
 overflow-checks = true
 panic = "abort"
@@ -22,3 +19,6 @@ debug = 0
 strip = "symbols"
 debug-assertions = false
 panic = "abort"
+
+[dependencies]
+stellar-contract-sdk = {path = "../../sdk"}

--- a/examples/add/Cargo.toml
+++ b/examples/add/Cargo.toml
@@ -10,3 +10,15 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}
+
+[profile.dev]
+overflow-checks = true
+panic = "abort"
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"

--- a/examples/liqpool/Cargo.toml
+++ b/examples/liqpool/Cargo.toml
@@ -8,6 +8,19 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[profile.dev]
+overflow-checks = true
+panic = "abort"
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+
+
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr" }

--- a/examples/liqpool/Cargo.toml
+++ b/examples/liqpool/Cargo.toml
@@ -8,18 +8,6 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.dev]
-overflow-checks = true
-panic = "abort"
-
-[profile.release]
-opt-level = "z"
-overflow-checks = true
-debug = 0
-strip = "symbols"
-debug-assertions = false
-panic = "abort"
-
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr" }

--- a/examples/liqpool/Cargo.toml
+++ b/examples/liqpool/Cargo.toml
@@ -20,7 +20,6 @@ strip = "symbols"
 debug-assertions = false
 panic = "abort"
 
-
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr" }

--- a/examples/token/Cargo.toml
+++ b/examples/token/Cargo.toml
@@ -8,17 +8,5 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.dev]
-overflow-checks = true
-panic = "abort"
-
-[profile.release]
-opt-level = "z"
-overflow-checks = true
-debug = 0
-strip = "symbols"
-debug-assertions = false
-panic = "abort"
-
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}

--- a/examples/token/Cargo.toml
+++ b/examples/token/Cargo.toml
@@ -8,5 +8,18 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[profile.dev]
+overflow-checks = true
+panic = "abort"
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+
+
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}

--- a/examples/token/Cargo.toml
+++ b/examples/token/Cargo.toml
@@ -20,6 +20,5 @@ strip = "symbols"
 debug-assertions = false
 panic = "abort"
 
-
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}


### PR DESCRIPTION
### What
Remove build profiles from sub crates.

### Why
Added in #66, but they get ignored by Cargo. We might want to structure our examples differently so they will contain build profiles.