### PR TITLE
Update xdr to get no_std and dropped deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,12 +30,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
 name = "example_add"
 version = "0.0.0"
 dependencies = [
@@ -147,10 +141,9 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr#a2ff409ba70fbe5315391a4bbae8bc784e05ee01"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=1fa7c3ebdefd6c78719ede6b294aa64e13077d2a#1fa7c3ebdefd6c78719ede6b294aa64e13077d2a"
 dependencies = [
  "base64",
- "byteorder",
 ]
 
 [[package]]

--- a/examples/liqpool/Cargo.toml
+++ b/examples/liqpool/Cargo.toml
@@ -10,5 +10,5 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr" }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "1fa7c3ebdefd6c78719ede6b294aa64e13077d2a", default-features = false }
 stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey" }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -8,7 +8,9 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[dependencies]
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "1fa7c3ebdefd6c78719ede6b294aa64e13077d2a", default-features = false }
+
 [target.'cfg(not(target_family="wasm"))'.dependencies]
 im-rc = "15.0.0"
 num-bigint = "0.4"
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr" }


### PR DESCRIPTION
### What

Update xdr, and made xdr a general dependency.

### Why

We'll use the dependency generally because the host crate uses it. Also the xdr is now no_std-able when default features are off, so usable within contract.

cc @graydon 

### Known limitations

N/A