### PR TITLE
Use RawObj ret vals from env crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-contract-env-common"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=7ba2c82#7ba2c82b2e1d633d7aa65ec90bb5f77df2f0a1b0"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=7ddb9de#7ddb9de02c9d5734f92c9cb162753012024c4320"
 dependencies = [
  "static_assertions",
  "stellar-xdr",
@@ -129,7 +129,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-guest"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=7ba2c82#7ba2c82b2e1d633d7aa65ec90bb5f77df2f0a1b0"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=7ddb9de#7ddb9de02c9d5734f92c9cb162753012024c4320"
 dependencies = [
  "stellar-contract-env-common",
 ]
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-host"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=7ba2c82#7ba2c82b2e1d633d7aa65ec90bb5f77df2f0a1b0"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=7ddb9de#7ddb9de02c9d5734f92c9cb162753012024c4320"
 dependencies = [
  "im-rc",
  "num-bigint",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -11,9 +11,9 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 
 [target.'cfg(target_family="wasm")'.dependencies]
-stellar-contract-env-guest = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "7ba2c82", feature ="panic_handler" }
+stellar-contract-env-guest = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "7ddb9de", feature ="panic_handler" }
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
-stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "7ba2c82" }
+stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "7ddb9de" }
 im-rc = "15.0.0"
 num-bigint = "0.4"

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -62,14 +62,14 @@ impl<T: EnvValType + RawValType> Vec<T> {
     pub fn put(&mut self, i: u32, v: T) {
         let env = self.env();
         let vec = env.vec_put(self.0.as_ref().val, i.into(), v.into_raw_val(env));
-        self.0 = vec.in_env(env).try_into().or_abort();
+        self.0 = vec.in_env(env);
     }
 
     #[inline(always)]
     pub fn del(&mut self, i: u32) {
         let env = self.env();
         let vec = env.vec_del(self.0.as_ref().val, i.into());
-        self.0 = vec.in_env(env).try_into().or_abort();
+        self.0 = vec.in_env(env);
     }
 
     #[inline(always)]
@@ -83,28 +83,28 @@ impl<T: EnvValType + RawValType> Vec<T> {
     pub fn push(&mut self, x: T) {
         let env = self.env();
         let vec = env.vec_push(self.0.as_ref().val, x.into_raw_val(env));
-        self.0 = vec.in_env(env).try_into().or_abort();
+        self.0 = vec.in_env(env);
     }
 
     #[inline(always)]
     pub fn pop(&mut self) {
         let env = self.env();
         let vec = env.vec_pop(self.0.as_ref().val);
-        self.0 = vec.in_env(env).try_into().or_abort();
+        self.0 = vec.in_env(env);
     }
 
     #[inline(always)]
     pub fn take(&mut self, n: u32) {
         let env = self.env();
         let vec = env.vec_take(self.0.as_ref().val, n.into());
-        self.0 = vec.in_env(env).try_into().or_abort();
+        self.0 = vec.in_env(env);
     }
 
     #[inline(always)]
     pub fn drop(&mut self, n: u32) {
         let env = self.0.env();
         let vec = env.vec_drop(self.0.as_ref().val, n.into());
-        self.0 = vec.in_env(env).try_into().or_abort();
+        self.0 = vec.in_env(env);
     }
 
     #[inline(always)]
@@ -125,14 +125,14 @@ impl<T: EnvValType + RawValType> Vec<T> {
     pub fn insert(&mut self, i: u32, x: T) {
         let env = self.env();
         let vec = env.vec_put(self.0.as_ref().val, i.into(), x.into_raw_val(env));
-        self.0 = vec.in_env(env).try_into().or_abort();
+        self.0 = vec.in_env(env);
     }
 
     #[inline(always)]
     pub fn append(&mut self, other: Vec<T>) {
         let env = self.env();
         let vec = env.vec_append(self.0.as_ref().val, other.0.as_ref().val);
-        self.0 = vec.in_env(env).try_into().or_abort();
+        self.0 = vec.in_env(env);
     }
 }
 


### PR DESCRIPTION
### What

Use RawObj ret vals from env crate.

### Why

The env crate returns RawObjs now, so there's no need to coerce RawVals into RawObjs.

Related to https://github.com/stellar/rs-stellar-contract-sdk/pull/76

### Known limitations

N/A