### PR TITLE
Rename Object to EnvObj

### DIFF
--- a/sdk/src/bignum.rs
+++ b/sdk/src/bignum.rs
@@ -3,16 +3,16 @@ use core::{
     ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Not, Rem, Shl, Shr, Sub},
 };
 
-use super::{xdr::ScObjectType, Object, RawVal};
+use super::{xdr::ScObjectType, EnvObj, RawVal};
 
 #[repr(transparent)]
 #[derive(Clone)]
-pub struct BigNum(Object);
+pub struct BigNum(EnvObj);
 
-impl TryFrom<Object> for BigNum {
+impl TryFrom<EnvObj> for BigNum {
     type Error = ();
 
-    fn try_from(obj: Object) -> Result<Self, Self::Error> {
+    fn try_from(obj: EnvObj) -> Result<Self, Self::Error> {
         if obj.is_obj_type(ScObjectType::ScoBigint) {
             Ok(BigNum(obj))
         } else {
@@ -34,7 +34,7 @@ impl TryFrom<Object> for BigNum {
 //     }
 // }
 
-impl From<BigNum> for Object {
+impl From<BigNum> for EnvObj {
     fn from(b: BigNum) -> Self {
         b.0
     }
@@ -218,7 +218,7 @@ impl Ord for BigNum {
 }
 
 impl BigNum {
-    unsafe fn unchecked_new(obj: Object) -> Self {
+    unsafe fn unchecked_new(obj: EnvObj) -> Self {
         Self(obj)
     }
 

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -7,8 +7,6 @@ mod guest {
 
     pub use stellar_contract_env_guest::BitSet;
     pub use stellar_contract_env_guest::Env as EnvI;
-    pub use stellar_contract_env_guest::EnvObj;
-    pub use stellar_contract_env_guest::EnvVal;
     pub use stellar_contract_env_guest::EnvValType;
     pub use stellar_contract_env_guest::OrAbort;
     pub use stellar_contract_env_guest::RawVal;
@@ -17,7 +15,8 @@ mod guest {
     pub use stellar_contract_env_guest::Symbol;
 
     pub type Env = stellar_contract_env_guest::Guest;
-    pub type Object = stellar_contract_env_guest::EnvObj<Env>;
+    pub type EnvObj = stellar_contract_env_guest::EnvObj<Env>;
+    pub type EnvVal = stellar_contract_env_guest::EnvVal<Env>;
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -29,8 +28,6 @@ mod host {
 
     pub use stellar_contract_env_host::BitSet;
     pub use stellar_contract_env_host::Env as EnvI;
-    pub use stellar_contract_env_host::EnvObj;
-    pub use stellar_contract_env_host::EnvVal;
     pub use stellar_contract_env_host::EnvValType;
     pub use stellar_contract_env_host::OrAbort;
     pub use stellar_contract_env_host::RawVal;
@@ -39,5 +36,6 @@ mod host {
     pub use stellar_contract_env_host::Symbol;
 
     pub type Env = stellar_contract_env_host::Host;
-    pub type Object = EnvObj<Env>;
+    pub type EnvObj = stellar_contract_env_host::EnvObj<Env>;
+    pub type EnvVal = stellar_contract_env_host::EnvVal<Env>;
 }

--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -1,15 +1,15 @@
 use core::marker::PhantomData;
 
-use super::{xdr::ScObjectType, Object, RawVal, RawValType, Vec};
+use super::{xdr::ScObjectType, EnvObj, RawVal, RawValType, Vec};
 
 #[repr(transparent)]
 #[derive(Clone)]
-pub struct Map<K, V>(Object, PhantomData<K>, PhantomData<V>);
+pub struct Map<K, V>(EnvObj, PhantomData<K>, PhantomData<V>);
 
-impl<K: RawValType, V: RawValType> TryFrom<Object> for Map<K, V> {
+impl<K: RawValType, V: RawValType> TryFrom<EnvObj> for Map<K, V> {
     type Error = ();
 
-    fn try_from(obj: Object) -> Result<Self, Self::Error> {
+    fn try_from(obj: EnvObj) -> Result<Self, Self::Error> {
         if obj.is_obj_type(ScObjectType::ScoMap) {
             Ok(Map(obj, PhantomData, PhantomData))
         } else {
@@ -28,7 +28,7 @@ impl<K: RawValType, V: RawValType> TryFrom<RawVal> for Map<K, V> {
     }
 }
 
-impl<K: RawValType, V: RawValType> From<Map<K, V>> for Object {
+impl<K: RawValType, V: RawValType> From<Map<K, V>> for EnvObj {
     #[inline(always)]
     fn from(m: Map<K, V>) -> Self {
         m.0

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -1,15 +1,15 @@
 use core::marker::PhantomData;
 
-use super::{xdr::ScObjectType, Env, EnvI, EnvValType, Object, OrAbort, RawVal};
+use super::{xdr::ScObjectType, Env, EnvI, EnvObj, EnvValType, OrAbort, RawVal};
 
 #[derive(Clone)]
 #[repr(transparent)]
-pub struct Vec<T>(Object, PhantomData<T>);
+pub struct Vec<T>(EnvObj, PhantomData<T>);
 
-impl<V: EnvValType> TryFrom<Object> for Vec<V> {
+impl<V: EnvValType> TryFrom<EnvObj> for Vec<V> {
     type Error = ();
 
-    fn try_from(obj: Object) -> Result<Self, Self::Error> {
+    fn try_from(obj: EnvObj) -> Result<Self, Self::Error> {
         if obj.is_obj_type(ScObjectType::ScoVec) {
             Ok(Vec(obj, PhantomData))
         } else {
@@ -18,7 +18,7 @@ impl<V: EnvValType> TryFrom<Object> for Vec<V> {
     }
 }
 
-impl<T: EnvValType> From<Vec<T>> for Object {
+impl<T: EnvValType> From<Vec<T>> for EnvObj {
     #[inline(always)]
     fn from(v: Vec<T>) -> Self {
         v.0
@@ -33,7 +33,7 @@ impl<T: EnvValType> From<Vec<T>> for RawVal {
 }
 
 impl<T: EnvValType> Vec<T> {
-    unsafe fn unchecked_new(obj: Object) -> Self {
+    unsafe fn unchecked_new(obj: EnvObj) -> Self {
         Self(obj, PhantomData)
     }
 
@@ -44,7 +44,7 @@ impl<T: EnvValType> Vec<T> {
     #[inline(always)]
     pub fn new(env: &Env) -> Vec<T> {
         let val = env.vec_new();
-        let obj: Object = val.in_env(env).try_into().or_abort();
+        let obj: EnvObj = val.in_env(env).try_into().or_abort();
         unsafe { Self::unchecked_new(obj) }
     }
 


### PR DESCRIPTION
### What

Rename `Object` to `EnvObj`, aliasing over the generic version of `EnvObj<Env>`.

### Why

The SDK, at this time, aliases over the `Env` trait with a concrete `Env` implementation. It simplifies the SDK code. It is a bit confusing we have `Object` that also does this but with a different unique name. It's simpler I think if when we do this aliasing we use the same names.

### Known limitations

N/A

cc @graydon 