### PR TITLE
Unexport EnvObj/EnvVal

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -8,8 +8,6 @@
 mod env;
 pub use env::BitSet;
 pub use env::Env;
-pub use env::EnvObj;
-pub use env::EnvVal;
 pub use env::EnvValType;
 pub use env::OrAbort;
 pub use env::RawVal;


### PR DESCRIPTION
### What

Unexport EnvObj/EnvVal.

### Why

At the moment the contracts are using RawVal and concrete types, and not the intermediary types that are really just for internal use. We can reexport these if necessary.

### Known limitations

N/A