### PR TITLE
Reimpl the BigInt type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-contract-env-common"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=0867b519#0867b519ae5415fbb061af5fade29c4adb0018a1"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=dee50def#dee50def2f514288a5d6d2d1f5634232477371e3"
 dependencies = [
  "static_assertions",
  "stellar-xdr",
@@ -154,7 +154,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-guest"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=0867b519#0867b519ae5415fbb061af5fade29c4adb0018a1"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=dee50def#dee50def2f514288a5d6d2d1f5634232477371e3"
 dependencies = [
  "stellar-contract-env-common",
 ]
@@ -162,7 +162,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-host"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=0867b519#0867b519ae5415fbb061af5fade29c4adb0018a1"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=dee50def#dee50def2f514288a5d6d2d1f5634232477371e3"
 dependencies = [
  "im-rc",
  "num-bigint",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -11,11 +11,11 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 
 [target.'cfg(target_family="wasm")'.dependencies]
-stellar-contract-env-guest = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "0867b519", features = ["panic_handler"] }
+stellar-contract-env-guest = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "dee50def", features = ["panic_handler"] }
 # stellar-contract-env-guest = { path = "../../rs-stellar-contract-env/stellar-contract-env-guest" }
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
-stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "0867b519" }
+stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "dee50def" }
 # stellar-contract-env-host = { path = "../../rs-stellar-contract-env/stellar-contract-env-host" }
 im-rc = "15.0.0"
 num-bigint = "0.4"

--- a/sdk/src/bigint.rs
+++ b/sdk/src/bigint.rs
@@ -336,14 +336,3 @@ impl BigInt {
         u32::try_from(bits).or_abort()
     }
 }
-
-#[cfg(test)]
-mod test {
-    use crate::{Env, BigInt, Vec};
-    #[test]
-    pub fn bigint_inside_vec() {
-        let env = Env::default();
-        let mut vec = Vec::<BigInt>::new(&env);
-        vec.push(BigInt::from_u64(&env, 1));
-    }
-}

--- a/sdk/src/bigint.rs
+++ b/sdk/src/bigint.rs
@@ -336,3 +336,14 @@ impl BigInt {
         u32::try_from(bits).or_abort()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::{Env, BigInt, Vec};
+    #[test]
+    pub fn bigint_inside_vec() {
+        let env = Env::default();
+        let mut vec = Vec::<BigInt>::new(&env);
+        vec.push(BigInt::from_u64(&env, 1));
+    }
+}

--- a/sdk/src/bigint.rs
+++ b/sdk/src/bigint.rs
@@ -55,7 +55,7 @@ impl TryFrom<BigInt> for u64 {
 
     fn try_from(b: BigInt) -> Result<Self, Self::Error> {
         if b.bits() <= u64::BITS {
-            Ok(b.to_u64())
+            Ok(unsafe { b.to_u64() })
         } else {
             Err(())
         }
@@ -67,7 +67,7 @@ impl TryFrom<BigInt> for i64 {
 
     fn try_from(b: BigInt) -> Result<Self, Self::Error> {
         if b.bits() <= i64::BITS {
-            Ok(b.to_i64())
+            Ok(unsafe { b.to_i64() })
         } else {
             Err(())
         }
@@ -79,7 +79,7 @@ impl TryFrom<BigInt> for u32 {
 
     fn try_from(b: BigInt) -> Result<Self, Self::Error> {
         if b.bits() <= u32::BITS {
-            Ok(b.to_u32())
+            Ok(unsafe { b.to_u32() })
         } else {
             Err(())
         }
@@ -91,7 +91,7 @@ impl TryFrom<BigInt> for i32 {
 
     fn try_from(b: BigInt) -> Result<Self, Self::Error> {
         if b.bits() <= i32::BITS {
-            Ok(b.to_i32())
+            Ok(unsafe { b.to_i32() })
         } else {
             Err(())
         }
@@ -257,7 +257,7 @@ impl BigInt {
         unsafe { Self::unchecked_new(obj) }
     }
 
-    pub fn to_u64(&self) -> u64 {
+    unsafe fn to_u64(&self) -> u64 {
         let env = self.env();
         env.bigint_to_u64(self.0.to_tagged())
     }
@@ -267,7 +267,7 @@ impl BigInt {
         unsafe { Self::unchecked_new(obj) }
     }
 
-    pub fn to_i64(&self) -> i64 {
+    unsafe fn to_i64(&self) -> i64 {
         let env = self.env();
         env.bigint_to_i64(self.0.to_tagged())
     }
@@ -277,7 +277,7 @@ impl BigInt {
         unsafe { Self::unchecked_new(obj) }
     }
 
-    pub fn to_u32(&self) -> u32 {
+    unsafe fn to_u32(&self) -> u32 {
         let env = self.env();
         let u = env.bigint_to_u64(self.0.to_tagged());
         u.try_into().or_abort()
@@ -288,7 +288,7 @@ impl BigInt {
         unsafe { Self::unchecked_new(obj) }
     }
 
-    pub fn to_i32(&self) -> i32 {
+    unsafe fn to_i32(&self) -> i32 {
         let env = self.env();
         let i = env.bigint_to_i64(self.0.to_tagged());
         i.try_into().or_abort()

--- a/sdk/src/bigint.rs
+++ b/sdk/src/bigint.rs
@@ -3,11 +3,22 @@ use core::{
     ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Not, Rem, Shl, Shr, Sub},
 };
 
-use super::{xdr::ScObjectType, EnvObj, RawVal};
+use super::{
+    xdr::ScObjectType, Env, EnvBase, EnvObj, EnvTrait, EnvVal, EnvValConvertible, OrAbort, RawVal,
+};
 
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct BigInt(EnvObj);
+
+impl TryFrom<EnvVal<RawVal>> for BigInt {
+    type Error = ();
+
+    fn try_from(ev: EnvVal<RawVal>) -> Result<Self, Self::Error> {
+        let obj: EnvObj = ev.clone().try_into()?;
+        obj.try_into()
+    }
+}
 
 impl TryFrom<EnvObj> for BigInt {
     type Error = ();
@@ -21,18 +32,17 @@ impl TryFrom<EnvObj> for BigInt {
     }
 }
 
-// impl TryFrom<RawVal> for BigNum {
-//     type Error = ();
+impl From<BigInt> for RawVal {
+    fn from(b: BigInt) -> Self {
+        b.0.into()
+    }
+}
 
-//     fn try_from(val: RawVal) -> Result<Self, Self::Error> {
-//         let obj: Object = val.try_into()?;
-//         if obj.is_type(ScObjectType::ScoBigint) {
-//             Ok(BigNum(obj))
-//         } else {
-//             Err(())
-//         }
-//     }
-// }
+impl From<BigInt> for EnvVal<RawVal> {
+    fn from(b: BigInt) -> Self {
+        b.0.into()
+    }
+}
 
 impl From<BigInt> for EnvObj {
     fn from(b: BigInt) -> Self {
@@ -40,151 +50,167 @@ impl From<BigInt> for EnvObj {
     }
 }
 
-impl From<BigInt> for RawVal {
-    fn from(b: BigInt) -> Self {
-        b.0.into()
+impl TryFrom<BigInt> for u64 {
+    type Error = ();
+
+    fn try_from(b: BigInt) -> Result<Self, Self::Error> {
+        if b.bits() <= u64::BITS {
+            Ok(b.to_u64())
+        } else {
+            Err(())
+        }
     }
 }
 
-impl From<u64> for BigInt {
-    fn from(_x: u64) -> Self {
-        // unsafe { Self::unchecked_new(host::bignum::from_u64(x)) }
-        todo!()
+impl TryFrom<BigInt> for i64 {
+    type Error = ();
+
+    fn try_from(b: BigInt) -> Result<Self, Self::Error> {
+        if b.bits() <= i64::BITS {
+            Ok(b.to_i64())
+        } else {
+            Err(())
+        }
     }
 }
 
-impl From<BigInt> for u64 {
-    fn from(_b: BigInt) -> Self {
-        // unsafe { host::bignum::to_u64(b.into()) }
-        todo!()
+impl TryFrom<BigInt> for u32 {
+    type Error = ();
+
+    fn try_from(b: BigInt) -> Result<Self, Self::Error> {
+        if b.bits() <= u32::BITS {
+            Ok(b.to_u32())
+        } else {
+            Err(())
+        }
     }
 }
 
-impl From<i64> for BigInt {
-    fn from(_x: i64) -> Self {
-        // unsafe { Self::unchecked_new(host::bignum::from_i64(x)) }
-        todo!()
+impl TryFrom<BigInt> for i32 {
+    type Error = ();
+
+    fn try_from(b: BigInt) -> Result<Self, Self::Error> {
+        if b.bits() <= i32::BITS {
+            Ok(b.to_i32())
+        } else {
+            Err(())
+        }
     }
 }
-
-impl From<BigInt> for i64 {
-    fn from(_b: BigInt) -> Self {
-        // unsafe { host::bignum::to_i64(b.into()) }
-        todo!()
-    }
-}
-
-impl From<u32> for BigInt {
-    fn from(_x: u32) -> Self {
-        // unsafe { Self::unchecked_new(host::bignum::from_u64(x.into())) }
-        todo!()
-    }
-}
-
-// TODO: impl From<BigNum> for u32
-
-impl From<i32> for BigInt {
-    fn from(_x: i32) -> Self {
-        // unsafe { Self::unchecked_new(host::bignum::from_i64(x.into())) }
-        todo!()
-    }
-}
-
-// TODO: impl From<BigNum> for i32
 
 impl Add for BigInt {
     type Output = BigInt;
-    fn add(self, _rhs: Self) -> Self::Output {
-        // unsafe { Self::unchecked_new(host::bignum::add(self.into(), rhs.into())) }
-        todo!()
+    fn add(self, rhs: Self) -> Self::Output {
+        let env = self.env();
+        env.check_same_env(rhs.env());
+        let b = env.bigint_add(self.0.to_tagged(), rhs.0.to_tagged());
+        Self::try_from_val(env, b).or_abort()
     }
 }
 
 impl Sub for BigInt {
     type Output = BigInt;
-    fn sub(self, _rhs: Self) -> Self::Output {
-        // unsafe { Self::unchecked_new(host::bignum::sub(self.into(), rhs.into())) }
-        todo!()
+    fn sub(self, rhs: Self) -> Self::Output {
+        let env = self.env();
+        env.check_same_env(rhs.env());
+        let b = env.bigint_sub(self.0.to_tagged(), rhs.0.to_tagged());
+        Self::try_from_val(env, b).or_abort()
     }
 }
 
 impl Mul for BigInt {
     type Output = BigInt;
-    fn mul(self, _rhs: Self) -> Self::Output {
-        // unsafe { Self::unchecked_new(host::bignum::mul(self.into(), rhs.into())) }
-        todo!()
+    fn mul(self, rhs: Self) -> Self::Output {
+        let env = self.env();
+        env.check_same_env(rhs.env());
+        let b = env.bigint_mul(self.0.to_tagged(), rhs.0.to_tagged());
+        Self::try_from_val(env, b).or_abort()
     }
 }
 
 impl Div for BigInt {
     type Output = BigInt;
-    fn div(self, _rhs: Self) -> Self::Output {
-        // unsafe { Self::unchecked_new(host::bignum::div(self.into(), rhs.into())) }
-        todo!()
+    fn div(self, rhs: Self) -> Self::Output {
+        let env = self.env();
+        env.check_same_env(rhs.env());
+        let b = env.bigint_div(self.0.to_tagged(), rhs.0.to_tagged());
+        Self::try_from_val(env, b).or_abort()
     }
 }
 
 impl Rem for BigInt {
     type Output = BigInt;
-    fn rem(self, _rhs: Self) -> Self::Output {
-        // unsafe { Self::unchecked_new(host::bignum::rem(self.into(), rhs.into())) }
-        todo!()
+    fn rem(self, rhs: Self) -> Self::Output {
+        let env = self.env();
+        env.check_same_env(rhs.env());
+        let b = env.bigint_rem(self.0.to_tagged(), rhs.0.to_tagged());
+        Self::try_from_val(env, b).or_abort()
     }
 }
 
 impl BitAnd for BigInt {
     type Output = BigInt;
-    fn bitand(self, _rhs: Self) -> Self::Output {
-        // unsafe { Self::unchecked_new(host::bignum::and(self.into(), rhs.into())) }
-        todo!()
+    fn bitand(self, rhs: Self) -> Self::Output {
+        let env = self.env();
+        env.check_same_env(rhs.env());
+        let b = env.bigint_and(self.0.to_tagged(), rhs.0.to_tagged());
+        Self::try_from_val(env, b).or_abort()
     }
 }
 
 impl BitOr for BigInt {
     type Output = BigInt;
-    fn bitor(self, _rhs: Self) -> Self::Output {
-        // unsafe { Self::unchecked_new(host::bignum::or(self.into(), rhs.into())) }
-        todo!()
+    fn bitor(self, rhs: Self) -> Self::Output {
+        let env = self.env();
+        env.check_same_env(rhs.env());
+        let b = env.bigint_or(self.0.to_tagged(), rhs.0.to_tagged());
+        Self::try_from_val(env, b).or_abort()
     }
 }
 
 impl BitXor for BigInt {
     type Output = BigInt;
-    fn bitxor(self, _rhs: Self) -> Self::Output {
-        // unsafe { Self::unchecked_new(host::bignum::xor(self.into(), rhs.into())) }
-        todo!()
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        let env = self.env();
+        env.check_same_env(rhs.env());
+        let b = env.bigint_xor(self.0.to_tagged(), rhs.0.to_tagged());
+        Self::try_from_val(env, b).or_abort()
     }
 }
 
 impl Neg for BigInt {
     type Output = BigInt;
     fn neg(self) -> Self::Output {
-        // unsafe { Self::unchecked_new(host::bignum::neg(self.into())) }
-        todo!()
+        let env = self.env();
+        let b = env.bigint_neg(self.0.to_tagged());
+        Self::try_from_val(env, b).or_abort()
     }
 }
 
 impl Not for BigInt {
     type Output = BigInt;
     fn not(self) -> Self::Output {
-        // unsafe { Self::unchecked_new(host::bignum::not(self.into())) }
-        todo!()
+        let env = self.env();
+        let b = env.bigint_not(self.0.to_tagged());
+        Self::try_from_val(env, b).or_abort()
     }
 }
 
-impl Shl<u64> for BigInt {
+impl Shl<i32> for BigInt {
     type Output = BigInt;
-    fn shl(self, _rhs: u64) -> Self::Output {
-        // unsafe { Self::unchecked_new(host::bignum::shl(self.into(), rhs)) }
-        todo!()
+    fn shl(self, rhs: i32) -> Self::Output {
+        let env = self.env();
+        let b = env.bigint_shl(self.0.to_tagged(), rhs.into());
+        Self::try_from_val(env, b).or_abort()
     }
 }
 
-impl Shr<u64> for BigInt {
+impl Shr<i32> for BigInt {
     type Output = BigInt;
-    fn shr(self, _rhs: u64) -> Self::Output {
-        // unsafe { Self::unchecked_new(host::bignum::shr(self.into(), rhs)) }
-        todo!()
+    fn shr(self, rhs: i32) -> Self::Output {
+        let env = self.env();
+        let b = env.bigint_shl(self.0.to_tagged(), rhs.into());
+        Self::try_from_val(env, b).or_abort()
     }
 }
 
@@ -201,19 +227,19 @@ impl PartialOrd for BigInt {
 }
 
 impl Eq for BigInt {}
+
 impl Ord for BigInt {
-    fn cmp(&self, _other: &Self) -> Ordering {
-        // let i = unsafe {
-        //     <i32 as RawValType>::unchecked_from_val(host::bignum::cmp((*self).into(), (*other).into()))
-        todo!()
-        // };
-        // if i < 0 {
-        //     Ordering::Less
-        // } else if i > 0 {
-        //     Ordering::Greater
-        // } else {
-        //     Ordering::Equal
-        // }
+    fn cmp(&self, other: &Self) -> Ordering {
+        let env = self.env();
+        let v = env.bigint_cmp(self.0.to_tagged(), other.0.to_tagged());
+        let i = i32::try_from(v).or_abort();
+        if i < 0 {
+            Ordering::Less
+        } else if i > 0 {
+            Ordering::Greater
+        } else {
+            Ordering::Equal
+        }
     }
 }
 
@@ -222,38 +248,91 @@ impl BigInt {
         Self(obj)
     }
 
-    pub fn gcd(&self, _other: BigInt) -> BigInt {
-        // unsafe { Self::unchecked_new(host::bignum::gcd((*self).into(), other.into())) }
-        todo!()
+    fn env(&self) -> &Env {
+        self.0.env()
     }
 
-    pub fn lcm(&self, _other: BigInt) -> BigInt {
-        // unsafe { Self::unchecked_new(host::bignum::lcm((*self).into(), other.into())) }
-        todo!()
+    pub fn from_u64(env: &Env, u: u64) -> BigInt {
+        let obj = env.bigint_from_u64(u).in_env(env);
+        unsafe { Self::unchecked_new(obj) }
     }
 
-    pub fn pow(&self, _k: u64) -> BigInt {
-        // unsafe { Self::unchecked_new(host::bignum::pow((*self).into(), k)) }
-        todo!()
+    pub fn to_u64(&self) -> u64 {
+        let env = self.env();
+        env.bigint_to_u64(self.0.to_tagged())
     }
 
-    pub fn pow_mod(&self, _q: BigInt, _m: BigInt) -> BigInt {
-        // unsafe { Self::unchecked_new(host::bignum::pow_mod((*self).into(), q.into(), m.into())) }
-        todo!()
+    pub fn from_i64(env: &Env, i: i64) -> BigInt {
+        let obj = env.bigint_from_i64(i).in_env(env);
+        unsafe { Self::unchecked_new(obj) }
+    }
+
+    pub fn to_i64(&self) -> i64 {
+        let env = self.env();
+        env.bigint_to_i64(self.0.to_tagged())
+    }
+
+    pub fn from_u32(env: &Env, u: u32) -> BigInt {
+        let obj = env.bigint_from_u64(u as u64).in_env(env);
+        unsafe { Self::unchecked_new(obj) }
+    }
+
+    pub fn to_u32(&self) -> u32 {
+        let env = self.env();
+        let u = env.bigint_to_u64(self.0.to_tagged());
+        u.try_into().or_abort()
+    }
+
+    pub fn from_i32(env: &Env, i: i32) -> BigInt {
+        let obj = env.bigint_from_i64(i as i64).in_env(env);
+        unsafe { Self::unchecked_new(obj) }
+    }
+
+    pub fn to_i32(&self) -> i32 {
+        let env = self.env();
+        let i = env.bigint_to_i64(self.0.to_tagged());
+        i.try_into().or_abort()
+    }
+
+    pub fn gcd(&self, other: BigInt) -> BigInt {
+        let env = self.env();
+        let b = env.bigint_gcd(self.0.to_tagged(), other.0.to_tagged());
+        Self::try_from_val(env, b).or_abort()
+    }
+
+    pub fn lcm(&self, other: BigInt) -> BigInt {
+        let env = self.env();
+        let b = env.bigint_lcm(self.0.to_tagged(), other.0.to_tagged());
+        Self::try_from_val(env, b).or_abort()
+    }
+
+    pub fn pow(&self, k: BigInt) -> BigInt {
+        let env = self.env();
+        let b = env.bigint_pow(self.0.to_tagged(), k.0.to_tagged());
+        Self::try_from_val(env, b).or_abort()
+    }
+
+    pub fn pow_mod(&self, q: BigInt, m: BigInt) -> BigInt {
+        let env = self.env();
+        let b = env.bigint_pow_mod(self.0.to_tagged(), q.0.to_tagged(), m.0.to_tagged());
+        Self::try_from_val(env, b).or_abort()
     }
 
     pub fn sqrt(&self) -> BigInt {
-        // unsafe { Self::unchecked_new(host::bignum::sqrt((*self).into())) }
-        todo!()
+        let env = self.env();
+        let b = env.bigint_sqrt(self.0.to_tagged());
+        Self::try_from_val(env, b).or_abort()
     }
 
     pub fn is_zero(&self) -> bool {
-        // unsafe { <bool as RawValType>::unchecked_from_val(host::bignum::is_zero((*self).into())) }
-        todo!()
+        let env = self.env();
+        let is_zero = env.bigint_is_zero(self.0.to_tagged());
+        bool::try_from(is_zero).or_abort()
     }
 
-    pub fn bits(&self) -> u64 {
-        // unsafe { host::bignum::bits((*self).into()) }
-        todo!()
+    pub fn bits(&self) -> u32 {
+        let env = self.env();
+        let bits = env.bigint_bits(self.0.to_tagged());
+        u32::try_from(bits).or_abort()
     }
 }

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -13,6 +13,7 @@ mod env {
 pub use env::xdr;
 pub use env::BitSet;
 pub use env::Env;
+pub use env::EnvBase;
 pub use env::EnvTrait;
 pub use env::EnvValConvertible;
 pub use env::IntoEnvVal;


### PR DESCRIPTION
### What

Reimplement the BigInt type.

### Why

I commented most of the internals after the recent reorg, and this brings the functionality back.

### Known limitations

I made some assumptions about the types of different values, such as the type of the `bits()` fn being u32. These are easily changed if they're incorrect.

There's an outstanding question about how to handle errors in conversions to u64/i64. Will the host trap? Should guest code check the number of bits first? Will the host communicate an error somehow? I've assumed the host will trap, which technically makes the `to_` fns unsafe, which is why they are not public.

cc @graydon @jayz22 
