### PR TITLE
Pass Env to contract fn by clone

### DIFF
--- a/examples/add_i32/src/lib.rs
+++ b/examples/add_i32/src/lib.rs
@@ -2,13 +2,13 @@
 use stellar_contract_sdk::{Env, EnvValConvertible, OrAbort, RawVal};
 
 #[no_mangle]
-pub fn add(e: &Env, a: RawVal, b: RawVal) -> RawVal {
-    let a: i32 = i32::try_from_val(e, a).or_abort();
-    let b: i32 = i32::try_from_val(e, b).or_abort();
+pub fn add(e: Env, a: RawVal, b: RawVal) -> RawVal {
+    let a: i32 = i32::try_from_val(&e, a).or_abort();
+    let b: i32 = i32::try_from_val(&e, b).or_abort();
 
     let c = a + b;
 
-    return c.into_val(e);
+    return c.into_val(&e);
 }
 
 #[cfg(test)]
@@ -18,11 +18,11 @@ mod test {
 
     #[test]
     fn test_add() {
-        let e = &Env::default();
-        let x = 10i32.into_val(e);
-        let y = 12i32.into_val(e);
-        let z = add(e, x, y);
-        let z = i32::try_from_val(e, z).or_abort();
+        let e = Env::default();
+        let x = 10i32.into_val(&e);
+        let y = 12i32.into_val(&e);
+        let z = add(e.clone(), x, y);
+        let z = i32::try_from_val(&e, z).or_abort();
         assert!(z == 22);
     }
 }

--- a/examples/add_i64/src/lib.rs
+++ b/examples/add_i64/src/lib.rs
@@ -2,13 +2,13 @@
 use stellar_contract_sdk::{Env, EnvValConvertible, OrAbort, RawVal};
 
 #[no_mangle]
-pub fn add(e: &Env, a: RawVal, b: RawVal) -> RawVal {
-    let a: i64 = i64::try_from_val(e, a).or_abort();
-    let b: i64 = i64::try_from_val(e, b).or_abort();
+pub fn add(e: Env, a: RawVal, b: RawVal) -> RawVal {
+    let a: i64 = i64::try_from_val(&e, a).or_abort();
+    let b: i64 = i64::try_from_val(&e, b).or_abort();
 
     let c = a + b;
 
-    return c.into_val(e);
+    return c.into_val(&e);
 }
 
 #[cfg(test)]
@@ -18,11 +18,11 @@ mod test {
 
     #[test]
     fn test_add() {
-        let e = &Env::default();
-        let x = 10i64.into_val(e);
-        let y = 12i64.into_val(e);
-        let z = add(e, x, y);
-        let z = i64::try_from_val(e, z).or_abort();
+        let e = Env::default();
+        let x = 10i64.into_val(&e);
+        let y = 12i64.into_val(&e);
+        let z = add(e.clone(), x, y);
+        let z = i64::try_from_val(&e, z).or_abort();
         assert!(z == 22);
     }
 }


### PR DESCRIPTION
### What

Pass Env to contract fn by clone.

### Why

Passing the Env by reference causes it to become an i32 param in the wasm32 build, but we want the zero sized struct to be omitted in the wasm.

### Known limitations

[TODO or N/A]
