### PR TITLE
Add the most basic NFT example that is not really an NFT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "example_pixel_nft"
+version = "0.0.0"
+dependencies = [
+ "stellar-contract-sdk",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "sdk",
     "examples/add_i32",
     "examples/add_i64",
+    "examples/pixel_nft",
 ]
 
 [profile.dev]

--- a/examples/pixel_nft/Cargo.toml
+++ b/examples/pixel_nft/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example_pixel_nft"
+version = "0.0.0"
+authors = ["Stellar Development Foundation <info@stellar.org>"]
+license = "Apache-2.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+stellar-contract-sdk = {path = "../../sdk"}

--- a/examples/pixel_nft/src/lib.rs
+++ b/examples/pixel_nft/src/lib.rs
@@ -1,14 +1,19 @@
 #![no_std]
-use stellar_contract_sdk::{Env, IntoVal, RawVal};
+use stellar_contract_sdk::{Env, IntoVal, RawVal, Symbol};
 
 #[no_mangle]
 pub fn pixel(e: Env) -> RawVal {
     0x957dad00u32.into_val(&e)
 }
 
+#[no_mangle]
+pub fn owner(e: Env) -> RawVal {
+    Symbol::from_str("GBKLMQVNCR").into_val(&e)
+}
+
 #[cfg(test)]
 mod test {
-    use stellar_contract_sdk::{Env, TryFromVal};
+    use stellar_contract_sdk::{Env, Symbol, TryFromVal};
 
     #[test]
     fn pixel() {
@@ -16,5 +21,14 @@ mod test {
         let rgba = super::pixel(e.clone());
         let rgba = u32::try_from_val(&e, rgba).unwrap();
         assert_eq!(rgba, 0x957dad00);
+    }
+
+    #[test]
+    fn owner() {
+        let e = Env::default();
+        let owner = super::owner(e.clone());
+        let owner = Symbol::try_from_val(&e, owner).unwrap().to_str();
+        let owner: &str = owner.as_ref();
+        assert_eq!("GBKLMQVNCR", owner);
     }
 }

--- a/examples/pixel_nft/src/lib.rs
+++ b/examples/pixel_nft/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+use stellar_contract_sdk::{Env, IntoVal, RawVal};
+
+#[no_mangle]
+pub fn pixel(e: Env) -> RawVal {
+    0x957dad00u32.into_val(&e)
+}
+
+#[cfg(test)]
+mod test {
+    use stellar_contract_sdk::{Env, TryFromVal};
+
+    #[test]
+    fn pixel() {
+        let e = Env::default();
+        let rgba = super::pixel(e.clone());
+        let rgba = u32::try_from_val(&e, rgba).unwrap();
+        assert_eq!(rgba, 0x957dad00);
+    }
+}

--- a/examples/pixel_nft/src/lib.rs
+++ b/examples/pixel_nft/src/lib.rs
@@ -3,7 +3,7 @@ use stellar_contract_sdk::{Env, IntoVal, RawVal, Symbol};
 
 #[no_mangle]
 pub fn pixel(e: Env) -> RawVal {
-    0x957dad00u32.into_val(&e)
+    0x957dadffu32.into_val(&e)
 }
 
 #[no_mangle]
@@ -20,7 +20,7 @@ mod test {
         let e = Env::default();
         let rgba = super::pixel(e.clone());
         let rgba = u32::try_from_val(&e, rgba).unwrap();
-        assert_eq!(rgba, 0x957dad00);
+        assert_eq!(rgba, 0x957dadff);
     }
 
     #[test]


### PR DESCRIPTION
### What

Add the most basic NFT example that is not really an NFT for @paulbellamy to experiment with.

### Why

@paulbellamy wanted an NFT for a dapp example. 

### Known limitations

The example provides a single pixel because the SDK and env don't yet have strings, or binary support, which makes having the contract return an image URL or an image binary difficult right now. The example doesn't have an owner, because that part of the interop hasn't been finalized yet, nor have account IDs or public keys been implemented yet.

This example can be repurposed into a more meaningful NFT once we have more things implemented.