### PR TITLE
Add is_empty to Vec, Map

### DIFF
--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -121,6 +121,11 @@ impl<K: EnvRawValConvertible, V: EnvRawValConvertible> Map<K, V> {
     }
 
     #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[inline(always)]
     pub fn len(&self) -> u32 {
         let env = self.env();
         let len = env.map_len(self.0.to_tagged());

--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -1,4 +1,4 @@
-use core::marker::PhantomData;
+use core::{cmp::Ordering, marker::PhantomData};
 
 use super::{
     xdr::ScObjectType, Env, EnvObj, EnvRawValConvertible, EnvTrait, EnvVal, RawVal, TryFromVal, Vec,
@@ -7,6 +7,29 @@ use super::{
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct Map<K, V>(EnvObj, PhantomData<K>, PhantomData<V>);
+
+impl<K: EnvRawValConvertible, V: EnvRawValConvertible> Eq for Map<K, V> {}
+
+impl<K: EnvRawValConvertible, V: EnvRawValConvertible> PartialEq for Map<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.partial_cmp(other) == Some(Ordering::Equal)
+    }
+}
+
+impl<K: EnvRawValConvertible, V: EnvRawValConvertible> PartialOrd for Map<K, V> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(Ord::cmp(self, other))
+    }
+}
+
+impl<K: EnvRawValConvertible, V: EnvRawValConvertible> Ord for Map<K, V> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        let env = self.env();
+        let v = env.obj_cmp(self.0.to_raw(), other.0.to_raw());
+        let i = i32::try_from(v).unwrap();
+        i.cmp(&0)
+    }
+}
 
 impl<K: EnvRawValConvertible, V: EnvRawValConvertible> TryFrom<EnvVal<RawVal>> for Map<K, V> {
     type Error = ();

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -114,6 +114,11 @@ impl<T: EnvRawValConvertible> Vec<T> {
     }
 
     #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[inline(always)]
     pub fn len(&self) -> u32 {
         let env = self.env();
         let val = env.vec_len(self.0.to_tagged());


### PR DESCRIPTION
### What

Add is_empty to Vec, Map.

### Why

Conventional to provide an `is_empty()` wherever a `len()` exists.

### Known limitations

[TODO or N/A]
