### PR TITLE
Small tidy fixes

### DIFF
--- a/sdk/src/bigint.rs
+++ b/sdk/src/bigint.rs
@@ -231,13 +231,7 @@ impl Ord for BigInt {
         let env = self.env();
         let v = env.bigint_cmp(self.0.to_tagged(), other.0.to_tagged());
         let i = i32::try_from(v).unwrap();
-        if i < 0 {
-            Ordering::Less
-        } else if i > 0 {
-            Ordering::Greater
-        } else {
-            Ordering::Equal
-        }
+        i.cmp(&0)
     }
 }
 

--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -36,7 +36,7 @@ impl<K: EnvRawValConvertible, V: EnvRawValConvertible> TryFrom<EnvVal<RawVal>> f
 
     #[inline(always)]
     fn try_from(ev: EnvVal<RawVal>) -> Result<Self, Self::Error> {
-        let obj: EnvObj = ev.clone().try_into()?;
+        let obj: EnvObj = ev.try_into()?;
         obj.try_into()
     }
 }
@@ -83,7 +83,7 @@ impl<K: EnvRawValConvertible, V: EnvRawValConvertible> Map<K, V> {
 
     #[inline(always)]
     fn env(&self) -> &Env {
-        &self.0.env()
+        self.0.env()
     }
 
     #[inline(always)]

--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -121,6 +121,11 @@ impl<K: EnvRawValConvertible, V: EnvRawValConvertible> Map<K, V> {
     }
 
     #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[inline(always)]
     pub fn len(&self) -> u32 {
         let env = self.env();
         let len = env.map_len(self.0.to_tagged());

--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -1,4 +1,4 @@
-use core::marker::PhantomData;
+use core::{cmp::Ordering, marker::PhantomData};
 
 use super::{
     xdr::ScObjectType, Env, EnvObj, EnvRawValConvertible, EnvTrait, EnvVal, RawVal, TryFromVal, Vec,
@@ -7,6 +7,29 @@ use super::{
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct Map<K, V>(EnvObj, PhantomData<K>, PhantomData<V>);
+
+impl<K: EnvRawValConvertible, V: EnvRawValConvertible> Eq for Map<K, V> {}
+
+impl<K: EnvRawValConvertible, V: EnvRawValConvertible> PartialEq for Map<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.partial_cmp(other) == Some(Ordering::Equal)
+    }
+}
+
+impl<K: EnvRawValConvertible, V: EnvRawValConvertible> PartialOrd for Map<K, V> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(Ord::cmp(self, other))
+    }
+}
+
+impl<K: EnvRawValConvertible, V: EnvRawValConvertible> Ord for Map<K, V> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        let env = self.env();
+        let v = env.obj_cmp(self.0.to_raw(), other.0.to_raw());
+        let i = i32::try_from(v).unwrap();
+        i.cmp(&0)
+    }
+}
 
 impl<K: EnvRawValConvertible, V: EnvRawValConvertible> TryFrom<EnvVal<RawVal>> for Map<K, V> {
     type Error = ();

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -34,7 +34,7 @@ impl<T: EnvRawValConvertible> TryFrom<EnvVal<RawVal>> for Vec<T> {
 
     #[inline(always)]
     fn try_from(ev: EnvVal<RawVal>) -> Result<Self, Self::Error> {
-        let obj: EnvObj = ev.clone().try_into()?;
+        let obj: EnvObj = ev.try_into()?;
         obj.try_into()
     }
 }
@@ -80,7 +80,7 @@ impl<T: EnvRawValConvertible> Vec<T> {
 
     #[inline(always)]
     fn env(&self) -> &Env {
-        &self.0.env()
+        self.0.env()
     }
 
     #[inline(always)]

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -114,6 +114,11 @@ impl<T: EnvRawValConvertible> Vec<T> {
     }
 
     #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[inline(always)]
     pub fn len(&self) -> u32 {
         let env = self.env();
         let val = env.vec_len(self.0.to_tagged());


### PR DESCRIPTION
### What

Several small tidy fixes:
- Remove if block for integer comparison
- Remove unnecessary clones
- Remove unnecessary borrows

### Why

Linter pointed the unnecessary codes out.

### Known limitations

[TODO or N/A]
