### PR TITLE
Rename some SDK alias types

### DIFF
--- a/sdk/src/bigint.rs
+++ b/sdk/src/bigint.rs
@@ -9,10 +9,10 @@ use super::{env::internal::Env as _, Env, EnvBase, EnvObj, EnvVal, RawVal, TryFr
 #[derive(Clone)]
 pub struct BigInt(EnvObj);
 
-impl TryFrom<EnvVal<RawVal>> for BigInt {
+impl TryFrom<EnvVal> for BigInt {
     type Error = ();
 
-    fn try_from(ev: EnvVal<RawVal>) -> Result<Self, Self::Error> {
+    fn try_from(ev: EnvVal) -> Result<Self, Self::Error> {
         let obj: EnvObj = ev.clone().try_into()?;
         obj.try_into()
     }
@@ -37,7 +37,7 @@ impl From<BigInt> for RawVal {
     }
 }
 
-impl From<BigInt> for EnvVal<RawVal> {
+impl From<BigInt> for EnvVal {
     fn from(b: BigInt) -> Self {
         b.0.into()
     }

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -23,12 +23,11 @@ pub use internal::TaggedVal;
 pub use internal::TryFromVal;
 pub use internal::Val;
 
-pub type EnvVal<V> = internal::EnvVal<Env, V>;
+pub type EnvVal = internal::EnvVal<Env, RawVal>;
+pub type EnvObj = internal::EnvVal<Env, Object>;
 
-pub type EnvObj = EnvVal<Object>;
-
-pub trait EnvRawValConvertible: IntoVal<Env, RawVal> + TryFromVal<Env, RawVal> {}
-impl<C> EnvRawValConvertible for C where C: IntoVal<Env, RawVal> + TryFromVal<Env, RawVal> {}
+pub trait IntoTryFromVal: IntoVal<Env, RawVal> + TryFromVal<Env, RawVal> {}
+impl<C> IntoTryFromVal for C where C: IntoVal<Env, RawVal> + TryFromVal<Env, RawVal> {}
 
 #[derive(Clone, Default)]
 pub struct Env {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -11,6 +11,8 @@ use stellar_contract_env_panic_handler_wasm32_unreachable as _;
 mod env;
 pub use env::BitSet;
 pub use env::Env;
+pub use env::EnvVal;
+pub use env::IntoEnvVal;
 pub use env::IntoVal;
 pub use env::RawVal;
 pub use env::Status;

--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -1,7 +1,7 @@
 use core::{cmp::Ordering, marker::PhantomData};
 
 use super::{
-    env::internal::Env as _, xdr::ScObjectType, Env, EnvObj, EnvRawValConvertible, EnvVal, RawVal,
+    env::internal::Env as _, xdr::ScObjectType, Env, EnvObj, EnvVal, IntoTryFromVal, RawVal,
     TryFromVal, Vec,
 };
 
@@ -9,21 +9,21 @@ use super::{
 #[derive(Clone)]
 pub struct Map<K, V>(EnvObj, PhantomData<K>, PhantomData<V>);
 
-impl<K: EnvRawValConvertible, V: EnvRawValConvertible> Eq for Map<K, V> {}
+impl<K: IntoTryFromVal, V: IntoTryFromVal> Eq for Map<K, V> {}
 
-impl<K: EnvRawValConvertible, V: EnvRawValConvertible> PartialEq for Map<K, V> {
+impl<K: IntoTryFromVal, V: IntoTryFromVal> PartialEq for Map<K, V> {
     fn eq(&self, other: &Self) -> bool {
         self.partial_cmp(other) == Some(Ordering::Equal)
     }
 }
 
-impl<K: EnvRawValConvertible, V: EnvRawValConvertible> PartialOrd for Map<K, V> {
+impl<K: IntoTryFromVal, V: IntoTryFromVal> PartialOrd for Map<K, V> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(Ord::cmp(self, other))
     }
 }
 
-impl<K: EnvRawValConvertible, V: EnvRawValConvertible> Ord for Map<K, V> {
+impl<K: IntoTryFromVal, V: IntoTryFromVal> Ord for Map<K, V> {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         let env = self.env();
         let v = env.obj_cmp(self.0.to_raw(), other.0.to_raw());
@@ -32,17 +32,17 @@ impl<K: EnvRawValConvertible, V: EnvRawValConvertible> Ord for Map<K, V> {
     }
 }
 
-impl<K: EnvRawValConvertible, V: EnvRawValConvertible> TryFrom<EnvVal<RawVal>> for Map<K, V> {
+impl<K: IntoTryFromVal, V: IntoTryFromVal> TryFrom<EnvVal> for Map<K, V> {
     type Error = ();
 
     #[inline(always)]
-    fn try_from(ev: EnvVal<RawVal>) -> Result<Self, Self::Error> {
+    fn try_from(ev: EnvVal) -> Result<Self, Self::Error> {
         let obj: EnvObj = ev.try_into()?;
         obj.try_into()
     }
 }
 
-impl<K: EnvRawValConvertible, V: EnvRawValConvertible> TryFrom<EnvObj> for Map<K, V> {
+impl<K: IntoTryFromVal, V: IntoTryFromVal> TryFrom<EnvObj> for Map<K, V> {
     type Error = ();
 
     #[inline(always)]
@@ -55,28 +55,28 @@ impl<K: EnvRawValConvertible, V: EnvRawValConvertible> TryFrom<EnvObj> for Map<K
     }
 }
 
-impl<K: EnvRawValConvertible, V: EnvRawValConvertible> From<Map<K, V>> for RawVal {
+impl<K: IntoTryFromVal, V: IntoTryFromVal> From<Map<K, V>> for RawVal {
     #[inline(always)]
     fn from(m: Map<K, V>) -> Self {
         m.0.into()
     }
 }
 
-impl<K: EnvRawValConvertible, V: EnvRawValConvertible> From<Map<K, V>> for EnvVal<RawVal> {
+impl<K: IntoTryFromVal, V: IntoTryFromVal> From<Map<K, V>> for EnvVal {
     #[inline(always)]
     fn from(m: Map<K, V>) -> Self {
         m.0.into()
     }
 }
 
-impl<K: EnvRawValConvertible, V: EnvRawValConvertible> From<Map<K, V>> for EnvObj {
+impl<K: IntoTryFromVal, V: IntoTryFromVal> From<Map<K, V>> for EnvObj {
     #[inline(always)]
     fn from(m: Map<K, V>) -> Self {
         m.0
     }
 }
 
-impl<K: EnvRawValConvertible, V: EnvRawValConvertible> Map<K, V> {
+impl<K: IntoTryFromVal, V: IntoTryFromVal> Map<K, V> {
     #[inline(always)]
     unsafe fn unchecked_new(obj: EnvObj) -> Self {
         Self(obj, PhantomData, PhantomData)

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -1,28 +1,28 @@
 use core::{cmp::Ordering, marker::PhantomData};
 
 use super::{
-    env::internal::Env as _, xdr::ScObjectType, Env, EnvObj, EnvRawValConvertible, EnvVal, RawVal,
+    env::internal::Env as _, xdr::ScObjectType, Env, EnvObj, EnvVal, IntoTryFromVal, RawVal,
 };
 
 #[derive(Clone)]
 #[repr(transparent)]
 pub struct Vec<T>(EnvObj, PhantomData<T>);
 
-impl<T: EnvRawValConvertible> Eq for Vec<T> {}
+impl<T: IntoTryFromVal> Eq for Vec<T> {}
 
-impl<T: EnvRawValConvertible> PartialEq for Vec<T> {
+impl<T: IntoTryFromVal> PartialEq for Vec<T> {
     fn eq(&self, other: &Self) -> bool {
         self.partial_cmp(other) == Some(Ordering::Equal)
     }
 }
 
-impl<T: EnvRawValConvertible> PartialOrd for Vec<T> {
+impl<T: IntoTryFromVal> PartialOrd for Vec<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(Ord::cmp(self, other))
     }
 }
 
-impl<T: EnvRawValConvertible> Ord for Vec<T> {
+impl<T: IntoTryFromVal> Ord for Vec<T> {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         let env = self.env();
         let v = env.obj_cmp(self.0.to_raw(), other.0.to_raw());
@@ -31,17 +31,17 @@ impl<T: EnvRawValConvertible> Ord for Vec<T> {
     }
 }
 
-impl<T: EnvRawValConvertible> TryFrom<EnvVal<RawVal>> for Vec<T> {
+impl<T: IntoTryFromVal> TryFrom<EnvVal> for Vec<T> {
     type Error = ();
 
     #[inline(always)]
-    fn try_from(ev: EnvVal<RawVal>) -> Result<Self, Self::Error> {
+    fn try_from(ev: EnvVal) -> Result<Self, Self::Error> {
         let obj: EnvObj = ev.try_into()?;
         obj.try_into()
     }
 }
 
-impl<T: EnvRawValConvertible> TryFrom<EnvObj> for Vec<T> {
+impl<T: IntoTryFromVal> TryFrom<EnvObj> for Vec<T> {
     type Error = ();
 
     #[inline(always)]
@@ -54,27 +54,27 @@ impl<T: EnvRawValConvertible> TryFrom<EnvObj> for Vec<T> {
     }
 }
 
-impl<T: EnvRawValConvertible> From<Vec<T>> for RawVal {
+impl<T: IntoTryFromVal> From<Vec<T>> for RawVal {
     #[inline(always)]
     fn from(v: Vec<T>) -> Self {
         v.0.into()
     }
 }
 
-impl<T: EnvRawValConvertible> From<Vec<T>> for EnvVal<RawVal> {
+impl<T: IntoTryFromVal> From<Vec<T>> for EnvVal {
     fn from(v: Vec<T>) -> Self {
         v.0.into()
     }
 }
 
-impl<T: EnvRawValConvertible> From<Vec<T>> for EnvObj {
+impl<T: IntoTryFromVal> From<Vec<T>> for EnvObj {
     #[inline(always)]
     fn from(v: Vec<T>) -> Self {
         v.0
     }
 }
 
-impl<T: EnvRawValConvertible> Vec<T> {
+impl<T: IntoTryFromVal> Vec<T> {
     #[inline(always)]
     unsafe fn unchecked_new(obj: EnvObj) -> Self {
         Self(obj, PhantomData)


### PR DESCRIPTION
### What

Rename some SDK alias types.

### Why

Some more consistency.

### Known limitations

[TODO or N/A]
