### PR TITLE
Add an example of manually encoding a user-defined type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "example_udt"
+version = "0.0.0"
+dependencies = [
+ "stellar-contract-sdk",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "sdk",
     "examples/add_i32",
     "examples/add_i64",
+    "examples/udt",
 ]
 
 [profile.dev]

--- a/examples/udt/Cargo.toml
+++ b/examples/udt/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example_udt"
+version = "0.0.0"
+authors = ["Stellar Development Foundation <info@stellar.org>"]
+license = "Apache-2.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+stellar-contract-sdk = {path = "../../sdk"}

--- a/examples/udt/src/lib.rs
+++ b/examples/udt/src/lib.rs
@@ -6,6 +6,10 @@ pub struct Udt {
     pub b: i64,
 }
 
+// TODO: These trait implementations will be hidden behind a macro, and probably
+// be implemented using a Map rather than a tuple to provide for better data
+// migration.
+
 impl TryFrom<EnvVal> for Udt {
     type Error = ();
 

--- a/examples/udt/src/lib.rs
+++ b/examples/udt/src/lib.rs
@@ -1,0 +1,46 @@
+#![no_std]
+use stellar_contract_sdk::{Env, EnvVal, IntoEnvVal, IntoVal, RawVal, TryFromVal};
+
+pub struct Udt {
+    pub a: i64,
+    pub b: i64,
+}
+
+impl TryFrom<EnvVal> for Udt {
+    type Error = ();
+
+    fn try_from(ev: EnvVal) -> Result<Self, Self::Error> {
+        let (a, b): (i64, i64) = ev.try_into()?;
+        Ok(Udt { a, b })
+    }
+}
+
+impl IntoEnvVal<Env, RawVal> for Udt {
+    fn into_env_val(self, env: &Env) -> EnvVal {
+        (self.a, self.b).into_env_val(env)
+    }
+}
+
+#[no_mangle]
+pub fn add(e: Env, udt: RawVal) -> RawVal {
+    let udt: Udt = Udt::try_from_val(&e, udt).unwrap();
+
+    let c = udt.a + udt.b;
+
+    return c.into_val(&e);
+}
+
+#[cfg(test)]
+mod test {
+    use super::{add, Udt};
+    use stellar_contract_sdk::{Env, IntoVal, TryFromVal};
+
+    #[test]
+    fn test_add() {
+        let e = Env::default();
+        let udt = Udt { a: 10, b: 12 }.into_val(&e);
+        let z = add(e.clone(), udt);
+        let z = i64::try_from_val(&e, z).unwrap();
+        assert!(z == 22);
+    }
+}


### PR DESCRIPTION
### What

Add an example of manually encoding a Udt.

### Why

@jonjove and I were discussing how user-defined types would work, and it occurred to me that we can start experimenting with different models now by just coding them manually. In the SDK any type that can satisfy the `IntoTryFromVal` trait can be used in all the places other supporte types are used, like in Vecs, or in the contract storage fns.

### Known limitations

This is just a simple example using tuples. It's highly likely that when we implement the macro for writing this code automatically that it will produce a Map instead.
