### PR TITLE
Implement Binary and FixedLengthBinary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,16 +610,16 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-contract-env-common"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=42fc83ac#42fc83acacc8d155a92d3b3aca8d917296c58704"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=0d6ace7#0d6ace7a2629b55211e64043236831fbd9986b69"
 dependencies = [
  "static_assertions",
- "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=277d41c3)",
+ "stellar-xdr",
 ]
 
 [[package]]
 name = "stellar-contract-env-guest"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=42fc83ac#42fc83acacc8d155a92d3b3aca8d917296c58704"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=0d6ace7#0d6ace7a2629b55211e64043236831fbd9986b69"
 dependencies = [
  "stellar-contract-env-common",
 ]
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-host"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=42fc83ac#42fc83acacc8d155a92d3b3aca8d917296c58704"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=0d6ace7#0d6ace7a2629b55211e64043236831fbd9986b69"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-panic-handler-wasm32-unreachable"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=42fc83ac#42fc83acacc8d155a92d3b3aca8d917296c58704"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=0d6ace7#0d6ace7a2629b55211e64043236831fbd9986b69"
 
 [[package]]
 name = "stellar-contract-macros"
@@ -652,7 +652,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=0b8fe26)",
+ "stellar-xdr",
  "syn",
 ]
 
@@ -664,7 +664,7 @@ dependencies = [
  "stellar-contract-env-host",
  "stellar-contract-env-panic-handler-wasm32-unreachable",
  "stellar-contract-macros",
- "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=0b8fe26)",
+ "stellar-xdr",
  "trybuild",
 ]
 
@@ -672,14 +672,6 @@ dependencies = [
 name = "stellar-xdr"
 version = "0.0.0"
 source = "git+https://github.com/stellar/rs-stellar-xdr?rev=0b8fe26#0b8fe269f5468625294e110d496e7a24804bb9b8"
-dependencies = [
- "base64",
-]
-
-[[package]]
-name = "stellar-xdr"
-version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=277d41c3#277d41c3c1e1ebd5ad91ff3c190cdb1fe42954c7"
 dependencies = [
  "base64",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +73,80 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+]
+
+[[package]]
+name = "ed25519"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.9",
+ "zeroize",
+]
 
 [[package]]
 name = "either"
@@ -107,6 +199,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,8 +227,14 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "im-rc"
@@ -124,7 +243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
 dependencies = [
  "bitmaps",
- "rand_core",
+ "rand_core 0.6.3",
  "rand_xoshiro",
  "sized-chunks",
  "typenum",
@@ -204,6 +323,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,8 +355,8 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "quick-error 2.0.1",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -261,13 +386,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -277,7 +425,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -286,7 +443,16 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.7",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -295,7 +461,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -304,7 +470,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -344,6 +510,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.137"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "signature"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
+
+[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,7 +564,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-contract-env-common"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=c55b5fe9#c55b5fe97bd500ddcbc9db34a083955d3fc9ea06"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=c97d37c#c97d37c34b7cd0b43fa17e1e7f740ed598b8f46e"
 dependencies = [
  "static_assertions",
  "stellar-xdr",
@@ -371,7 +573,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-guest"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=c55b5fe9#c55b5fe97bd500ddcbc9db34a083955d3fc9ea06"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=c97d37c#c97d37c34b7cd0b43fa17e1e7f740ed598b8f46e"
 dependencies = [
  "stellar-contract-env-common",
 ]
@@ -379,11 +581,14 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-host"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=c55b5fe9#c55b5fe97bd500ddcbc9db34a083955d3fc9ea06"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=c97d37c#c97d37c34b7cd0b43fa17e1e7f740ed598b8f46e"
 dependencies = [
+ "ed25519-dalek",
+ "hex",
  "im-rc",
  "num-bigint",
  "num-rational",
+ "sha2 0.10.2",
  "static_assertions",
  "stellar-contract-env-common",
  "thiserror",
@@ -423,6 +628,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "syn"
 version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +642,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -480,6 +703,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +722,12 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -521,3 +756,24 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zeroize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -12,12 +12,12 @@ crate-type = ["cdylib", "rlib"]
 stellar-contract-macros = { path = "../macros" }
 
 [target.'cfg(target_family="wasm")'.dependencies]
-stellar-contract-env-panic-handler-wasm32-unreachable = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "42fc83ac" }
-stellar-contract-env-guest = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "42fc83ac" }
+stellar-contract-env-panic-handler-wasm32-unreachable = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "0d6ace7" }
+stellar-contract-env-guest = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "0d6ace7" }
 # stellar-contract-env-guest = { path = "../../rs-stellar-contract-env/stellar-contract-env-guest" }
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
-stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "42fc83ac" }
+stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "0d6ace7" }
 # stellar-contract-env-host = { path = "../../rs-stellar-contract-env/stellar-contract-env-host" }
 
 [dev-dependencies]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -13,9 +13,9 @@ stellar-contract-macros = { path = "../macros" }
 
 [target.'cfg(target_family="wasm")'.dependencies]
 stellar-contract-env-panic-handler-wasm32-unreachable = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "c55b5fe9" }
-stellar-contract-env-guest = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "c55b5fe9" }
+stellar-contract-env-guest = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "c97d37c" }
 # stellar-contract-env-guest = { path = "../../rs-stellar-contract-env/stellar-contract-env-guest" }
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
-stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "c55b5fe9" }
+stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "c97d37c" }
 # stellar-contract-env-host = { path = "../../rs-stellar-contract-env/stellar-contract-env-host" }

--- a/sdk/src/binary.rs
+++ b/sdk/src/binary.rs
@@ -44,7 +44,7 @@ impl TryFrom<EnvObj> for Binary {
 
     #[inline(always)]
     fn try_from(obj: EnvObj) -> Result<Self, Self::Error> {
-        if obj.as_tagged().is_obj_type(ScObjectType::Vec) {
+        if obj.as_tagged().is_obj_type(ScObjectType::Binary) {
             Ok(unsafe { Binary::unchecked_new(obj) })
         } else {
             Err(())

--- a/sdk/src/binary.rs
+++ b/sdk/src/binary.rs
@@ -242,3 +242,42 @@ impl<const N: u32> From<FixedLengthBinary<N>> for Binary {
         v.0
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_bin() {
+        let env = Env::default();
+
+        let mut bin = Binary::new(&env);
+        assert_eq!(bin.len(), 0);
+        bin.push(10);
+        assert_eq!(bin.len(), 1);
+        bin.push(20);
+        assert_eq!(bin.len(), 2);
+        bin.push(30);
+        assert_eq!(bin.len(), 3);
+
+        let bin_ref = &bin;
+        assert_eq!(bin_ref.len(), 3);
+
+        let mut bin_copy = bin.clone();
+        assert!(bin == bin_copy);
+        assert_eq!(bin_copy.len(), 3);
+        bin_copy.push(40);
+        assert_eq!(bin_copy.len(), 4);
+        assert!(bin != bin_copy);
+
+        assert_eq!(bin.len(), 3);
+        assert_eq!(bin_ref.len(), 3);
+
+        bin_copy.pop();
+        assert!(bin == bin_copy);
+
+        let bad_fixed: Result<FixedLengthBinary<4>, ()> = bin.try_into();
+        assert!(!bad_fixed.is_ok());
+        let _fixed: FixedLengthBinary<3> = bin_copy.try_into().unwrap();
+    }
+}

--- a/sdk/src/binary.rs
+++ b/sdk/src/binary.rs
@@ -222,7 +222,7 @@ impl<const N: u32> FixedLengthBinary for ArrayBinary<N> {
 
     #[inline(always)]
     fn len(&self) -> u32 {
-        self.0.len()
+        N
     }
 
     #[inline(always)]

--- a/sdk/src/binary.rs
+++ b/sdk/src/binary.rs
@@ -1,0 +1,244 @@
+use core::cmp::Ordering;
+
+use super::{env::internal::Env as _, xdr::ScObjectType, Env, EnvObj, EnvVal, RawVal};
+
+#[derive(Clone)]
+#[repr(transparent)]
+pub struct Binary(EnvObj);
+
+impl Eq for Binary {}
+
+impl PartialEq for Binary {
+    fn eq(&self, other: &Self) -> bool {
+        self.partial_cmp(other) == Some(Ordering::Equal)
+    }
+}
+
+impl PartialOrd for Binary {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(Ord::cmp(self, other))
+    }
+}
+
+impl Ord for Binary {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        let env = self.env();
+        let v = env.obj_cmp(self.0.to_raw(), other.0.to_raw());
+        let i = i32::try_from(v).unwrap();
+        i.cmp(&0)
+    }
+}
+
+impl TryFrom<EnvVal> for Binary {
+    type Error = ();
+
+    #[inline(always)]
+    fn try_from(ev: EnvVal) -> Result<Self, Self::Error> {
+        let obj: EnvObj = ev.try_into()?;
+        obj.try_into()
+    }
+}
+
+impl TryFrom<EnvObj> for Binary {
+    type Error = ();
+
+    #[inline(always)]
+    fn try_from(obj: EnvObj) -> Result<Self, Self::Error> {
+        if obj.as_tagged().is_obj_type(ScObjectType::Vec) {
+            Ok(unsafe { Binary::unchecked_new(obj) })
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl From<Binary> for RawVal {
+    #[inline(always)]
+    fn from(v: Binary) -> Self {
+        v.0.into()
+    }
+}
+
+impl From<Binary> for EnvVal {
+    #[inline(always)]
+    fn from(v: Binary) -> Self {
+        v.0.into()
+    }
+}
+
+impl From<Binary> for EnvObj {
+    #[inline(always)]
+    fn from(v: Binary) -> Self {
+        v.0
+    }
+}
+
+impl Binary {
+    #[inline(always)]
+    unsafe fn unchecked_new(obj: EnvObj) -> Self {
+        Self(obj)
+    }
+
+    #[inline(always)]
+    fn env(&self) -> &Env {
+        self.0.env()
+    }
+
+    #[inline(always)]
+    pub fn new(env: &Env) -> Binary {
+        let obj = env.binary_new().in_env(env);
+        unsafe { Self::unchecked_new(obj) }
+    }
+
+    #[inline(always)]
+    pub fn put(&mut self, i: u32, v: u8) {
+        let v32: u32 = v.into();
+        self.0 = self
+            .env()
+            .binary_put(self.0.to_tagged(), i.into(), v32.into())
+            .in_env(self.env());
+    }
+
+    #[inline(always)]
+    pub fn get(&self, i: u32) -> u8 {
+        let res32: u32 = self
+            .env()
+            .binary_get(self.0.to_tagged(), i.into())
+            .try_into()
+            .unwrap();
+        res32.try_into().unwrap()
+    }
+
+    #[inline(always)]
+    pub fn del(&mut self, i: u32) {
+        self.0 = self
+            .env()
+            .binary_del(self.0.to_tagged(), i.into())
+            .in_env(self.env());
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> u32 {
+        self.env()
+            .binary_len(self.0.to_tagged())
+            .try_into()
+            .unwrap()
+    }
+
+    pub fn push(&mut self, x: u8) {
+        let x32: u32 = x.into();
+        self.0 = self
+            .env()
+            .binary_push(self.0.to_tagged(), x32.into())
+            .in_env(self.env());
+    }
+
+    pub fn pop(&mut self) {
+        self.0 = self.env().binary_pop(self.0.to_tagged()).in_env(self.env());
+    }
+
+    pub fn front(&self) -> u8 {
+        let res32: u32 = self
+            .env()
+            .binary_front(self.0.to_tagged())
+            .try_into()
+            .unwrap();
+        res32.try_into().unwrap()
+    }
+
+    pub fn back(&self) -> u8 {
+        let res32: u32 = self
+            .env()
+            .binary_back(self.0.to_tagged())
+            .try_into()
+            .unwrap();
+        res32.try_into().unwrap()
+    }
+
+    pub fn insert(&mut self, i: u32, x: u8) {
+        let x32: u32 = x.into();
+        self.0 = self
+            .env()
+            .binary_insert(self.0.to_tagged(), i.into(), x32.into())
+            .in_env(self.env());
+    }
+
+    pub fn append(&mut self, other: &Binary) {
+        self.0 = self
+            .env()
+            .binary_append(self.0.to_tagged(), other.0.to_tagged())
+            .in_env(self.env());
+    }
+}
+
+#[derive(Clone)]
+#[repr(transparent)]
+pub struct FixedLengthBinary<const N: u32>(Binary);
+
+impl<const N: u32> TryFrom<EnvVal> for FixedLengthBinary<N> {
+    type Error = ();
+
+    #[inline(always)]
+    fn try_from(ev: EnvVal) -> Result<Self, Self::Error> {
+        let obj: EnvObj = ev.try_into()?;
+        obj.try_into()
+    }
+}
+
+impl<const N: u32> TryFrom<EnvObj> for FixedLengthBinary<N> {
+    type Error = ();
+
+    #[inline(always)]
+    fn try_from(obj: EnvObj) -> Result<Self, Self::Error> {
+        let bin: Binary = obj.try_into()?;
+        bin.try_into()
+    }
+}
+
+impl<const N: u32> TryFrom<Binary> for FixedLengthBinary<N> {
+    type Error = ();
+
+    #[inline(always)]
+    fn try_from(bin: Binary) -> Result<Self, Self::Error> {
+        if bin.len() == N {
+            Ok(Self(bin))
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl<const N: u32> AsRef<Binary> for FixedLengthBinary<N> {
+    #[inline(always)]
+    fn as_ref(&self) -> &Binary {
+        &self.0
+    }
+}
+
+impl<const N: u32> From<FixedLengthBinary<N>> for RawVal {
+    #[inline(always)]
+    fn from(v: FixedLengthBinary<N>) -> Self {
+        v.0.into()
+    }
+}
+
+impl<const N: u32> From<FixedLengthBinary<N>> for EnvVal {
+    #[inline(always)]
+    fn from(v: FixedLengthBinary<N>) -> Self {
+        v.0.into()
+    }
+}
+
+impl<const N: u32> From<FixedLengthBinary<N>> for EnvObj {
+    #[inline(always)]
+    fn from(v: FixedLengthBinary<N>) -> Self {
+        v.0.into()
+    }
+}
+
+impl<const N: u32> From<FixedLengthBinary<N>> for Binary {
+    #[inline(always)]
+    fn from(v: FixedLengthBinary<N>) -> Self {
+        v.0
+    }
+}

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -10,6 +10,7 @@ pub mod internal {
     pub type EnvImpl = Host;
 }
 
+pub use crate::binary::{Binary, FixedLengthBinary};
 pub use internal::xdr;
 pub use internal::BitSet;
 pub use internal::EnvBase;
@@ -40,6 +41,12 @@ impl Env {
     // BigInt, etc. If there is any host fn we expect a developer to use, it
     // should be plumbed through this type with this type doing all RawVal
     // conversion.
+
+    pub fn get_invoking_contract(&self) -> FixedLengthBinary<32> {
+        let rv = internal::Env::get_invoking_contract(self).to_raw();
+        let bin = Binary::try_from_val(self, rv).map_err(|_| ()).unwrap();
+        bin.try_into().unwrap()
+    }
 
     pub fn put_contract_data<K: IntoTryFromVal, V: IntoTryFromVal>(&self, key: K, val: V) {
         internal::Env::put_contract_data(self, key.into_val(self), val.into_val(self));

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -10,7 +10,7 @@ pub mod internal {
     pub type EnvImpl = Host;
 }
 
-pub use crate::binary::{Binary, FixedLengthBinary};
+pub use crate::binary::{ArrayBinary, Binary};
 pub use internal::xdr;
 pub use internal::BitSet;
 pub use internal::EnvBase;
@@ -42,7 +42,7 @@ impl Env {
     // should be plumbed through this type with this type doing all RawVal
     // conversion.
 
-    pub fn get_invoking_contract(&self) -> FixedLengthBinary<32> {
+    pub fn get_invoking_contract(&self) -> ArrayBinary<32> {
         let rv = internal::Env::get_invoking_contract(self).to_raw();
         let bin = Binary::try_from_val(self, rv).map_err(|_| ()).unwrap();
         bin.try_into().unwrap()

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -23,8 +23,10 @@ pub use env::TryFromVal;
 use env::*;
 
 mod bigint;
+mod binary;
 mod map;
 mod vec;
 pub use bigint::BigInt;
+pub use binary::{Binary, FixedLengthBinary};
 pub use map::Map;
 pub use vec::Vec;


### PR DESCRIPTION
### What

Implements wrapper classes for `Binary` and `FixedLengthBinary`.

### Why

These are generally useful, but specifically are needed for CAP-54.

### Known limitations

Tests don't currently pass because binary host functions are not implemented in stellar-contract-env-host (cc @jayz22).