### PR TITLE
Improve contract data

### DIFF
--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -46,14 +46,9 @@ impl Env {
         rv.try_into().unwrap()
     }
 
-    pub fn get_contract_data<K, V>(&self, key: K) -> V
-    where
-        K: IntoVal<Env, RawVal>,
-        V: IntoTryFromVal,
-        <V as TryFrom<EnvVal>>::Error: std::fmt::Debug,
-    {
+    pub fn get_contract_data<K: IntoVal<Env, RawVal>, V: IntoTryFromVal>(&self, key: K) -> V {
         let rv = internal::Env::get_contract_data(self, key.into_val(self));
-        V::try_from_val(&self, rv).unwrap()
+        V::try_from_val(&self, rv).map_err(|_| ()).unwrap()
     }
 
     pub fn put_contract_data<K: IntoVal<Env, RawVal>, V: IntoTryFromVal>(&self, key: K, val: V) {

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -46,9 +46,14 @@ impl Env {
         rv.try_into().unwrap()
     }
 
-    pub fn get_contract_data<K: IntoVal<Env, RawVal>, V: IntoTryFromVal>(&self, key: K) -> V {
+    pub fn get_contract_data<K, V>(&self, key: K) -> V
+    where
+        K: IntoVal<Env, RawVal>,
+        V: IntoTryFromVal,
+        <V as TryFrom<EnvVal>>::Error: std::fmt::Debug,
+    {
         let rv = internal::Env::get_contract_data(self, key.into_val(self));
-        V::try_from_val(&self, rv).map_err(|_| ()).unwrap()
+        V::try_from_val(&self, rv).unwrap()
     }
 
     pub fn put_contract_data<K: IntoVal<Env, RawVal>, V: IntoTryFromVal>(&self, key: K, val: V) {

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -41,6 +41,11 @@ impl Env {
     // should be plumbed through this type with this type doing all RawVal
     // conversion.
 
+    pub fn has_contract_data<K: IntoVal<Env, RawVal>>(&self, key: K) -> bool {
+        let rv = internal::Env::has_contract_data(self, key.into_val(self));
+        rv.try_into().unwrap()
+    }
+
     pub fn get_contract_data<K: IntoVal<Env, RawVal>, V: IntoTryFromVal>(&self, key: K) -> V {
         let rv = internal::Env::get_contract_data(self, key.into_val(self));
         V::try_from_val(&self, rv).map_err(|_| ()).unwrap()

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -41,11 +41,16 @@ impl Env {
     // should be plumbed through this type with this type doing all RawVal
     // conversion.
 
-    pub fn put_contract_data<K: IntoTryFromVal, V: IntoTryFromVal>(&self, key: K, val: V) {
+    pub fn get_contract_data<K: IntoVal<Env, RawVal>, V: IntoTryFromVal>(&self, key: K) -> V {
+        let rv = internal::Env::get_contract_data(self, key.into_val(self));
+        V::try_from_val(&self, rv).map_err(|_| ()).unwrap()
+    }
+
+    pub fn put_contract_data<K: IntoVal<Env, RawVal>, V: IntoTryFromVal>(&self, key: K, val: V) {
         internal::Env::put_contract_data(self, key.into_val(self), val.into_val(self));
     }
 
-    pub fn del_contract_data<K: IntoTryFromVal>(&self, key: K) {
+    pub fn del_contract_data<K: IntoVal<Env, RawVal>>(&self, key: K) {
         internal::Env::del_contract_data(self, key.into_val(self));
     }
 }


### PR DESCRIPTION
### What

Clean-up the contract data interface and implement `has_contract_data`.

### Why

The contract data interface is needed for CAP-54, so I'm cleaning it up as I use it.

### Known limitations

None.