### PR TITLE
Fix macros std pollution in feature resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,7 +620,7 @@ version = "0.0.0"
 source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=633ff92#633ff92861920ca98d45262e541d3dfeb2bf8611"
 dependencies = [
  "static_assertions",
- "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=0b8fe26)",
+ "stellar-xdr",
 ]
 
 [[package]]
@@ -661,7 +661,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=277d41c)",
+ "stellar-xdr",
  "syn",
 ]
 
@@ -673,7 +673,7 @@ dependencies = [
  "stellar-contract-env-host",
  "stellar-contract-env-panic-handler-wasm32-unreachable",
  "stellar-contract-macros",
- "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=0b8fe26)",
+ "stellar-xdr",
  "trybuild",
 ]
 
@@ -681,14 +681,6 @@ dependencies = [
 name = "stellar-xdr"
 version = "0.0.0"
 source = "git+https://github.com/stellar/rs-stellar-xdr?rev=0b8fe26#0b8fe269f5468625294e110d496e7a24804bb9b8"
-dependencies = [
- "base64",
-]
-
-[[package]]
-name = "stellar-xdr"
-version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=277d41c#277d41c3c1e1ebd5ad91ff3c190cdb1fe42954c7"
 dependencies = [
  "base64",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,28 @@ resolver = "2"
 
 members = [
     "sdk",
-    "macros",
     "examples/add_i32",
     "examples/add_i64",
     "examples/udt",
     "examples/contract_data",
     "examples/create_contract",
+]
+
+# Exclude proc-macro crates from the workspace so that when building the
+# workspace their dependencies do not pollute the feature selection of other
+# crates. Ordinarily when you build a proc-macro crate as a dependency of
+# another crate, the proc-macro crate's dependencies are decoupled from the
+# dependencies of other crates. This has an important side-effect of not
+# unifiying the features selected in shared dependencies. When a proc-macro
+# crate is part of a workspace and the workspace as a whole is built the
+# proc-macro is seen as a first-class crate and its dependencies, including
+# their feature selection, affects the overall dependency graph used to build
+# all crates. This has an unfortunate side-effect for proc-macro crates, like
+# 'macros', that depend on std features when other crates, like 'sdk',
+# explicitly must not depend on std. Hopefully one day this will be fixed in:
+# https://github.com/rust-lang/cargo/issues/10827
+exclude = [
+    "macros"
 ]
 
 [profile.dev]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -28,7 +28,7 @@ proc-macro = true
 # (as a total hack) we depend on two _different_ versions of stellar-xdr, we can
 # configure them with separate features. Which is what we're doing (for now).
 
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "277d41c", features = ["next", "std"] }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "0b8fe26", features = ["next", "std"] }
 syn = {version="1.0",features=["full"]}
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -9,25 +9,6 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-
-# NB: For the time being (until we find a better solution, or abandon `no-std`
-# in the guest) we need to specify the stellar-xdr dependency for the the env
-# crate (pulled in transitively from the SDK crate) and the macros (this crate)
-# with _different versions_ of the stellar-xdr crate.
-#
-# To repeat (this is weird): ensure the rev="..." specified in this file is a
-# _different_ rev than the one specified in
-# https://github.com/stellar/rs-stellar-contract-env/blob/main/stellar-contract-env-common/Cargo.toml
-#
-# This is because the macros activate the `std` feature (as visible here) and
-# the guest crate when compiled to wasm requires _not_ activating the `std`
-# feature, to include a custom panic handler.
-#
-# If cargo resolves both dependencies to a single version of stellar-xdr, it
-# will enable the `std` feature in that "shared" version. If on the other hand
-# (as a total hack) we depend on two _different_ versions of stellar-xdr, we can
-# configure them with separate features. Which is what we're doing (for now).
-
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "0b8fe26", features = ["next", "std"] }
 syn = {version="1.0",features=["full"]}
 quote = "1.0"


### PR DESCRIPTION
### What

Exclude the stellar-contract-macros crate from the virtual workspace.

### Why

When building a lib crate that has a dependency on a proc_macro crate, and where both crates depend on a common dependency with different feature sets The features required by the lib and proc_macro crates get unified when the whole workspace is built together, even with resolver = 2 set.

When building the lib crate in isolation, or excluding the proc-macro crate from the virtual workspace, the features required by the lib and proc_macro creates are decoupled and do not impact each other.

See https://github.com/rust-lang/cargo/issues/10827

### Known limitations

If we ever add tests directly to the `stellar-contract-macros` crate they will not execute as part of running tests for the whole workspace. This is unlikely to be a real problem since to test the macro completely the tests need to be part of the `stellar-contract-sdk`, so we're unlikely to write tests in the macros crate.
