### PR TITLE
Type Checking: Remove generics from collection types

### DIFF
--- a/macros/src/derive_type.rs
+++ b/macros/src/derive_type.rs
@@ -44,7 +44,7 @@ pub fn derive_type_struct(ident: &Ident, data: &DataStruct, spec: bool) -> Token
                 }),
             };
             let map_key = quote! { stellar_contract_sdk::Symbol::from_str(#name) }; // TODO: Handle field names longer than a symbol. Hash the name? Truncate the name?
-            let try_from = quote! { #ident: map.get(#map_key).try_into()? };
+            let try_from = quote! { #ident: map.get::<_, EnvVal>(#map_key).try_into()? };
             let into = quote! { map.put(#map_key, self.#ident.into_env_val(env)) };
             (spec_field, try_from, into)
         })
@@ -85,7 +85,7 @@ pub fn derive_type_struct(ident: &Ident, data: &DataStruct, spec: bool) -> Token
             type Error = ConversionError;
             #[inline(always)]
             fn try_from(ev: EnvVal) -> Result<Self, Self::Error> {
-                let map: stellar_contract_sdk::Map<stellar_contract_sdk::Symbol, EnvVal> = ev.try_into()?;
+                let map: stellar_contract_sdk::Map = ev.try_into()?;
                 Ok(Self{
                     #(#try_froms,)*
                 })
@@ -95,7 +95,7 @@ pub fn derive_type_struct(ident: &Ident, data: &DataStruct, spec: bool) -> Token
         impl IntoEnvVal<Env, RawVal> for #ident {
             #[inline(always)]
             fn into_env_val(self, env: &Env) -> EnvVal {
-                let mut map = stellar_contract_sdk::Map::<stellar_contract_sdk::Symbol, EnvVal>::new(env);
+                let mut map = stellar_contract_sdk::Map::new(env);
                 #(#intos;)*
                 map.into()
             }

--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -1,8 +1,8 @@
 use core::{cmp::Ordering, fmt::Debug};
 
 use super::{
-    env::internal::Env as _, xdr::ScObjectType, ConversionError, Env, EnvObj, EnvVal, IntoVal,
-    RawVal, TryFromVal, Vec,
+    env::internal::Env as _, xdr::ScObjectType, ConversionError, Env, EnvObj, EnvVal,
+    IntoTryFromVal, IntoVal, RawVal, TryFromVal, Vec,
 };
 
 #[repr(transparent)]
@@ -137,7 +137,7 @@ impl Map {
     }
 
     #[inline(always)]
-    pub fn keys(&self) -> Vec {
+    pub fn keys<K: IntoTryFromVal>(&self) -> Vec<K> {
         let env = self.env();
         let vec = env.map_keys(self.0.to_tagged());
         Vec::try_from_val(env, vec).unwrap()

--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -134,9 +134,9 @@ impl<K: IntoTryFromVal, V: IntoTryFromVal> Map<K, V> {
     }
 
     #[inline(always)]
-    pub fn keys(&self) -> Vec<K> {
+    pub fn keys(&self) -> Vec {
         let env = self.env();
         let vec = env.map_keys(self.0.to_tagged());
-        Vec::<K>::try_from_val(env, vec).unwrap()
+        Vec::try_from_val(env, vec).unwrap()
     }
 }

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -1,29 +1,29 @@
-use core::{cmp::Ordering, marker::PhantomData};
+use core::cmp::Ordering;
 
 use super::{
-    env::internal::Env as _, xdr::ScObjectType, ConversionError, Env, EnvObj, EnvVal,
-    IntoTryFromVal, RawVal,
+    env::internal::Env as _, xdr::ScObjectType, ConversionError, Env, EnvObj, EnvVal, IntoVal,
+    RawVal, TryFromVal,
 };
 
 #[derive(Clone)]
 #[repr(transparent)]
-pub struct Vec<T>(EnvObj, PhantomData<T>);
+pub struct Vec(EnvObj);
 
-impl<T: IntoTryFromVal> Eq for Vec<T> {}
+impl Eq for Vec {}
 
-impl<T: IntoTryFromVal> PartialEq for Vec<T> {
+impl PartialEq for Vec {
     fn eq(&self, other: &Self) -> bool {
         self.partial_cmp(other) == Some(Ordering::Equal)
     }
 }
 
-impl<T: IntoTryFromVal> PartialOrd for Vec<T> {
+impl PartialOrd for Vec {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(Ord::cmp(self, other))
     }
 }
 
-impl<T: IntoTryFromVal> Ord for Vec<T> {
+impl Ord for Vec {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         let env = self.env();
         let v = env.obj_cmp(self.0.to_raw(), other.0.to_raw());
@@ -32,7 +32,7 @@ impl<T: IntoTryFromVal> Ord for Vec<T> {
     }
 }
 
-impl<T: IntoTryFromVal> TryFrom<EnvVal> for Vec<T> {
+impl TryFrom<EnvVal> for Vec {
     type Error = ConversionError;
 
     #[inline(always)]
@@ -42,43 +42,43 @@ impl<T: IntoTryFromVal> TryFrom<EnvVal> for Vec<T> {
     }
 }
 
-impl<T: IntoTryFromVal> TryFrom<EnvObj> for Vec<T> {
+impl TryFrom<EnvObj> for Vec {
     type Error = ConversionError;
 
     #[inline(always)]
     fn try_from(obj: EnvObj) -> Result<Self, Self::Error> {
         if obj.as_tagged().is_obj_type(ScObjectType::Vec) {
-            Ok(unsafe { Vec::<T>::unchecked_new(obj) })
+            Ok(unsafe { Vec::unchecked_new(obj) })
         } else {
             Err(ConversionError {})
         }
     }
 }
 
-impl<T: IntoTryFromVal> From<Vec<T>> for RawVal {
+impl From<Vec> for RawVal {
     #[inline(always)]
-    fn from(v: Vec<T>) -> Self {
+    fn from(v: Vec) -> Self {
         v.0.into()
     }
 }
 
-impl<T: IntoTryFromVal> From<Vec<T>> for EnvVal {
-    fn from(v: Vec<T>) -> Self {
+impl From<Vec> for EnvVal {
+    fn from(v: Vec) -> Self {
         v.0.into()
     }
 }
 
-impl<T: IntoTryFromVal> From<Vec<T>> for EnvObj {
+impl From<Vec> for EnvObj {
     #[inline(always)]
-    fn from(v: Vec<T>) -> Self {
+    fn from(v: Vec) -> Self {
         v.0
     }
 }
 
-impl<T: IntoTryFromVal> Vec<T> {
+impl Vec {
     #[inline(always)]
     unsafe fn unchecked_new(obj: EnvObj) -> Self {
-        Self(obj, PhantomData)
+        Self(obj)
     }
 
     #[inline(always)]
@@ -87,13 +87,13 @@ impl<T: IntoTryFromVal> Vec<T> {
     }
 
     #[inline(always)]
-    pub fn new(env: &Env) -> Vec<T> {
+    pub fn new(env: &Env) -> Vec {
         let obj = env.vec_new().in_env(env);
         unsafe { Self::unchecked_new(obj) }
     }
 
     #[inline(always)]
-    pub fn get(&self, i: u32) -> T {
+    pub fn get<T: TryFromVal<Env, RawVal>>(&self, i: u32) -> T {
         let env = self.env();
         let val = env.vec_get(self.0.to_tagged(), i.into());
         T::try_from_val(env, val).ok().unwrap()
@@ -103,7 +103,7 @@ impl<T: IntoTryFromVal> Vec<T> {
     // values of T? T values may be objects containing an Env?
 
     #[inline(always)]
-    pub fn put(&mut self, i: u32, v: T) {
+    pub fn put<T: IntoVal<Env, RawVal>>(&mut self, i: u32, v: T) {
         let env = self.env();
         let vec = env.vec_put(self.0.to_tagged(), i.into(), v.into_val(env));
         self.0 = vec.in_env(env);
@@ -129,7 +129,7 @@ impl<T: IntoTryFromVal> Vec<T> {
     }
 
     #[inline(always)]
-    pub fn push(&mut self, x: T) {
+    pub fn push<T: IntoVal<Env, RawVal>>(&mut self, x: T) {
         let env = self.env();
         let vec = env.vec_push(self.0.to_tagged(), x.into_val(env));
         self.0 = vec.in_env(env);
@@ -143,28 +143,28 @@ impl<T: IntoTryFromVal> Vec<T> {
     }
 
     #[inline(always)]
-    pub fn front(&self) -> T {
+    pub fn front<T: TryFromVal<Env, RawVal>>(&self) -> T {
         let env = self.0.env();
         let val = env.vec_front(self.0.to_tagged());
         T::try_from_val(env, val).ok().unwrap()
     }
 
     #[inline(always)]
-    pub fn back(&self) -> T {
+    pub fn back<T: TryFromVal<Env, RawVal>>(&self) -> T {
         let env = self.env();
         let val = env.vec_back(self.0.to_tagged());
         T::try_from_val(env, val).ok().unwrap()
     }
 
     #[inline(always)]
-    pub fn insert(&mut self, i: u32, x: T) {
+    pub fn insert<T: IntoVal<Env, RawVal>>(&mut self, i: u32, x: T) {
         let env = self.env();
         let vec = env.vec_put(self.0.to_tagged(), i.into(), x.into_val(env));
         self.0 = vec.in_env(env);
     }
 
     #[inline(always)]
-    pub fn append(&mut self, other: &Vec<T>) {
+    pub fn append(&mut self, other: &Vec) {
         let env = self.env();
         let vec = env.vec_append(self.0.to_tagged(), other.0.to_tagged());
         self.0 = vec.in_env(env);
@@ -179,13 +179,13 @@ mod test {
     fn test_vec_raw_val_type() {
         let env = Env::default();
 
-        let mut vec = Vec::<u32>::new(&env);
+        let mut vec = Vec::new(&env);
         assert_eq!(vec.len(), 0);
-        vec.push(10);
+        vec.push(10u32);
         assert_eq!(vec.len(), 1);
-        vec.push(20);
+        vec.push(20u32);
         assert_eq!(vec.len(), 2);
-        vec.push(30);
+        vec.push(30u32);
         assert_eq!(vec.len(), 3);
 
         let vec_ref = &vec;
@@ -194,7 +194,7 @@ mod test {
         let mut vec_copy = vec.clone();
         assert!(vec == vec_copy);
         assert_eq!(vec_copy.len(), 3);
-        vec_copy.push(40);
+        vec_copy.push(40u32);
         assert_eq!(vec_copy.len(), 4);
         assert!(vec != vec_copy);
 
@@ -209,13 +209,13 @@ mod test {
     fn test_vec_env_val_type() {
         let env = Env::default();
 
-        let mut vec = Vec::<i64>::new(&env);
+        let mut vec = Vec::new(&env);
         assert_eq!(vec.len(), 0);
-        vec.push(-10);
+        vec.push(-10i64);
         assert_eq!(vec.len(), 1);
-        vec.push(20);
+        vec.push(20i64);
         assert_eq!(vec.len(), 2);
-        vec.push(-30);
+        vec.push(-30i64);
         assert_eq!(vec.len(), 3);
 
         let vec_ref = &vec;
@@ -224,7 +224,7 @@ mod test {
         let mut vec_copy = vec.clone();
         assert!(vec == vec_copy);
         assert_eq!(vec_copy.len(), 3);
-        vec_copy.push(40);
+        vec_copy.push(40i64);
         assert_eq!(vec_copy.len(), 4);
         assert!(vec != vec_copy);
 
@@ -239,11 +239,11 @@ mod test {
     fn test_vec_recursive() {
         let env = Env::default();
 
-        let mut vec_inner = Vec::<i64>::new(&env);
-        vec_inner.push(-10);
+        let mut vec_inner = Vec::new(&env);
+        vec_inner.push(-10i64);
         assert_eq!(vec_inner.len(), 1);
 
-        let mut vec_outer = Vec::<Vec<i64>>::new(&env);
+        let mut vec_outer = Vec::new(&env);
         vec_outer.push(vec_inner);
         assert_eq!(vec_outer.len(), 1);
     }


### PR DESCRIPTION
### What

Remove the generic types from the collection types in the SDK:

- `Vec<T>` => `Vec`
- `Map<K, V>` => `Map`

### Why

It is convenient to represent the `Vec` and `Map` types as homogeneous data structures, but in reality there is nothing in the data definition (XDR) or the runtime environment that guarantees they will be. The SDK misrepresents the underlying data by presenting the collections as homogeneous, and while this misrepresentation is convenient in the common case, it could also be a cause of vulnerabilities since developers could assume the types are backed by values of the same type when they are not. @graydon, @jonjove, and I have discussed several options, including making the types homogeneous in the XDR, and including runtime checks. However, since the SDK type system is likely to be a super set of the runtime environment there are edge cases the host would be unable to test against.

Removing the generics from the types themselves and moving them to the functions so that the functions still aid with conversion seems like the most explicit way to make these types exhibit reality.

Related discussion https://discord.com/channels/897514728459468821/989953055829135380/993984627180056749

Close https://github.com/stellar/rs-stellar-contract-sdk/issues/152

### Known limitations

This will introduce some ambiguity into contracts.

❗ A `Vec` will allow any type to be added to it, even if the developer intends only a specific type to be added.

‼️ Also, exported types will no longer have `Vec<T>` as their field type, but instead just `Vec`. While this describes reality better, it is less effective at communicating the intent for what data should be placed in the `Vec`, and therefore this harms the developer experience. It seems better to harm the developer experience if the alternative is footgun code.

### TODO

The contract spec is not updated in this PR, and needs updating to remove the generic types from the specification of the collection types.