### PR TITLE
Replace some .ok() usage with including a constraint on Debug

### DIFF
--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -1,4 +1,4 @@
-use core::{cmp::Ordering, marker::PhantomData};
+use core::{cmp::Ordering, fmt::Debug, marker::PhantomData};
 
 use super::{
     env::internal::Env as _, xdr::ScObjectType, ConversionError, Env, EnvObj, EnvVal,
@@ -101,10 +101,13 @@ impl<K: IntoTryFromVal, V: IntoTryFromVal> Map<K, V> {
     }
 
     #[inline(always)]
-    pub fn get(&self, k: K) -> V {
+    pub fn get(&self, k: K) -> V
+    where
+        V::Error: Debug,
+    {
         let env = self.env();
         let v = env.map_get(self.0.to_tagged(), k.into_val(env));
-        V::try_from_val(env, v).ok().unwrap()
+        V::try_from_val(env, v).unwrap()
     }
 
     #[inline(always)]

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -1,4 +1,4 @@
-use core::{cmp::Ordering, marker::PhantomData};
+use core::{cmp::Ordering, fmt::Debug, marker::PhantomData};
 
 use super::{
     env::internal::Env as _, xdr::ScObjectType, ConversionError, Env, EnvObj, EnvVal,
@@ -93,10 +93,13 @@ impl<T: IntoTryFromVal> Vec<T> {
     }
 
     #[inline(always)]
-    pub fn get(&self, i: u32) -> T {
+    pub fn get(&self, i: u32) -> T
+    where
+        T::Error: Debug,
+    {
         let env = self.env();
         let val = env.vec_get(self.0.to_tagged(), i.into());
-        T::try_from_val(env, val).ok().unwrap()
+        T::try_from_val(env, val).unwrap()
     }
 
     // TODO: Do we need to check_same_env for the env potentially stored in
@@ -143,17 +146,23 @@ impl<T: IntoTryFromVal> Vec<T> {
     }
 
     #[inline(always)]
-    pub fn front(&self) -> T {
+    pub fn front(&self) -> T
+    where
+        T::Error: Debug,
+    {
         let env = self.0.env();
         let val = env.vec_front(self.0.to_tagged());
-        T::try_from_val(env, val).ok().unwrap()
+        T::try_from_val(env, val).unwrap()
     }
 
     #[inline(always)]
-    pub fn back(&self) -> T {
+    pub fn back(&self) -> T
+    where
+        T::Error: Debug,
+    {
         let env = self.env();
         let val = env.vec_back(self.0.to_tagged());
-        T::try_from_val(env, val).ok().unwrap()
+        T::try_from_val(env, val).unwrap()
     }
 
     #[inline(always)]


### PR DESCRIPTION
### What

Replace some .ok() usage with including a constraint on Debug.

### Why

Similar to https://github.com/stellar/rs-stellar-contract-sdk/issues/161 and https://github.com/stellar/rs-stellar-contract-sdk/pull/162, the conversion to an `Option` via the `.ok()` fn is unnecessary and hides information that `.unwrap()` when called on the Result would provide.

### Known limitations

[TODO or N/A]
