### PR TITLE
Generate Symbol at compile time for User-Defined Type in Contract Spec

### DIFF
--- a/macros/src/derive_type.rs
+++ b/macros/src/derive_type.rs
@@ -43,7 +43,7 @@ pub fn derive_type_struct(ident: &Ident, data: &DataStruct, spec: bool) -> Token
                     }
                 }),
             };
-            let map_key = quote! { stellar_contract_sdk::Symbol::from_str(#name) }; // TODO: Handle field names longer than a symbol. Hash the name? Truncate the name?
+            let map_key = quote! { { const k: stellar_contract_sdk::Symbol = stellar_contract_sdk::Symbol::from_str(#name); k } }; // TODO: Handle field names longer than a symbol. Hash the name? Truncate the name?
             let try_from = quote! { #ident: map.get(#map_key).try_into()? };
             let into = quote! { map.put(#map_key, self.#ident.into_env_val(env)) };
             (spec_field, try_from, into)


### PR DESCRIPTION
### What

Generate Symbol at compiler time for User-Defined Type in Contract Spec.

### Why

Symbols can be created at compile time because the fns for doing so are const fns, but the compiler will only evaluate them at compile time if the const fn is called in a const context. The Symbols for struct fields were being created at runtime because they weren't explicitly in a const context. This change causes them to be evaluated at compile time.

This change reduces the size of `example_udt.wasm` from `1809` to `1522` bytes.

Thanks to @jonjove who noticed this change in size when he started using the contract spec macros, and who noticed that the function being included is probably related to Symbol generation.

### Known limitations

[TODO or N/A]
