### PR TITLE
Map iterators, macro, debug

### DIFF
--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -2,8 +2,18 @@ use core::{cmp::Ordering, fmt::Debug, marker::PhantomData};
 
 use super::{
     env::internal::Env as _, xdr::ScObjectType, ConversionError, Env, EnvObj, EnvVal,
-    IntoTryFromVal, RawVal, TryFromVal, Vec,
+    IntoTryFromVal, RawVal, Status, TryFromVal, Vec,
 };
+
+#[macro_export]
+macro_rules! map {
+    ($env:expr) => {
+        $crate::Map::new($env)
+    };
+    ($env:expr, $(($k:expr, $v:expr)),+) => {
+        $crate::Map::from_array($env, [$(($k, $v)),+])
+    };
+}
 
 #[repr(transparent)]
 #[derive(Clone)]
@@ -29,6 +39,27 @@ impl<K: IntoTryFromVal, V: IntoTryFromVal> Ord for Map<K, V> {
         let v = env.obj_cmp(self.0.to_raw(), other.0.to_raw());
         let i = i32::try_from(v).unwrap();
         i.cmp(&0)
+    }
+}
+
+impl<K, V> Debug for Map<K, V>
+where
+    K: IntoTryFromVal + Debug + Clone,
+    K::Error: Debug,
+    V: IntoTryFromVal + Debug + Clone,
+    V::Error: Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Map(")?;
+        let mut iter = self.iter();
+        if let Some(x) = iter.next() {
+            write!(f, "{:?}", x)?;
+        }
+        for x in iter {
+            write!(f, ", {:?}", x)?;
+        }
+        write!(f, ")")?;
+        Ok(())
     }
 }
 
@@ -94,6 +125,15 @@ impl<K: IntoTryFromVal, V: IntoTryFromVal> Map<K, V> {
     }
 
     #[inline(always)]
+    pub fn from_array<const N: usize>(env: &Env, items: [(K, V); N]) -> Map<K, V> {
+        let mut map = Map::<K, V>::new(env);
+        for (k, v) in items {
+            map.put(k, v);
+        }
+        map
+    }
+
+    #[inline(always)]
     pub fn has(&self, k: K) -> bool {
         let env = self.env();
         let has = env.map_has(self.0.to_tagged(), k.into_val(env));
@@ -141,5 +181,196 @@ impl<K: IntoTryFromVal, V: IntoTryFromVal> Map<K, V> {
         let env = self.env();
         let vec = env.map_keys(self.0.to_tagged());
         Vec::<K>::try_from_val(env, vec).unwrap()
+    }
+
+    pub fn iter(&self) -> MapIter<K, V>
+    where
+        K: Clone,
+        K::Error: Debug,
+        V: Clone,
+        V::Error: Debug,
+    {
+        self.clone().into_iter()
+    }
+
+    fn get_val(&self, k: RawVal) -> RawVal {
+        let env = self.env();
+        env.map_get(self.0.to_tagged(), k)
+    }
+
+    fn min_key_val(&self) -> Option<RawVal> {
+        let env = self.env();
+        let result = env.map_min_key(self.0.to_object());
+        match Status::try_from(result) {
+            Ok(_) => None,
+            Err(ConversionError) => Some(result),
+        }
+    }
+
+    fn max_key_val(&self) -> Option<RawVal> {
+        let env = self.env();
+        let result = env.map_max_key(self.0.to_object());
+        match Status::try_from(result) {
+            Ok(_) => None,
+            Err(ConversionError) => Some(result),
+        }
+    }
+
+    fn next_key_val(&self, k: RawVal) -> Option<RawVal> {
+        let env = self.env();
+        let result = env.map_next_key(self.0.to_object(), k);
+        match Status::try_from(result) {
+            Ok(_) => None,
+            Err(ConversionError) => Some(result),
+        }
+    }
+
+    fn prev_key_val(&self, k: RawVal) -> Option<RawVal> {
+        let env = self.env();
+        let result = env.map_prev_key(self.0.to_object(), k);
+        match Status::try_from(result) {
+            Ok(_) => None,
+            Err(ConversionError) => Some(result),
+        }
+    }
+}
+
+impl<K, V> IntoIterator for Map<K, V>
+where
+    K: IntoTryFromVal,
+    K::Error: Debug,
+    V: IntoTryFromVal,
+    V::Error: Debug,
+{
+    type Item = (K, V);
+    type IntoIter = MapIter<K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        MapIter {
+            next_key: self.min_key_val(),
+            next_back_key: self.max_key_val(),
+            map: self,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct MapIter<K, V> {
+    map: Map<K, V>,
+    next_key: Option<RawVal>,
+    next_back_key: Option<RawVal>,
+}
+
+impl<K, V> MapIter<K, V> {
+    fn into_map(self) -> Map<K, V> {
+        self.map
+    }
+}
+
+impl<K, V> Iterator for MapIter<K, V>
+where
+    K: IntoTryFromVal,
+    K::Error: Debug,
+    V: IntoTryFromVal,
+    V::Error: Debug,
+{
+    type Item = (K, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_key.map(|next_key| {
+            let env = self.map.env();
+            let next_value = self.map.get_val(next_key);
+            self.next_key = self.map.next_key_val(next_key);
+            (
+                K::try_from_val(env, next_key).unwrap(),
+                V::try_from_val(env, next_value).unwrap(),
+            )
+        })
+    }
+}
+
+impl<K, V> DoubleEndedIterator for MapIter<K, V>
+where
+    K: IntoTryFromVal,
+    K::Error: Debug,
+    V: IntoTryFromVal,
+    V::Error: Debug,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.next_back_key.map(|next_back_key| {
+            let env = self.map.env();
+            let next_back_value = self.map.get_val(next_back_key);
+            self.next_back_key = self.map.prev_key_val(next_back_key);
+            (
+                K::try_from_val(env, next_back_key).unwrap(),
+                V::try_from_val(env, next_back_value).unwrap(),
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_empty() {
+        let env = Env::default();
+
+        let map: Map<(), ()> = map![&env];
+        assert_eq!(map.len(), 0);
+    }
+
+    #[test]
+    fn test_raw_vals() {
+        let env = Env::default();
+
+        let map: Map<u32, bool> = map![&env, (1, true), (2, false)];
+        assert_eq!(map.len(), 2);
+        assert!(map.get(1));
+        assert!(!map.get(2));
+    }
+
+    #[test]
+    fn test_iter() {
+        let env = Env::default();
+
+        let map: Map<(), ()> = map![&env];
+        let mut iter = map.iter();
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+
+        let map = map![&env, (0, 0), (1, 10), (2, 20), (3, 30), (4, 40)];
+
+        let mut iter = map.iter();
+        assert_eq!(iter.next(), Some((0, 0)));
+        assert_eq!(iter.next(), Some((1, 10)));
+        assert_eq!(iter.next(), Some((2, 20)));
+        assert_eq!(iter.next(), Some((3, 30)));
+        assert_eq!(iter.next(), Some((4, 40)));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+
+        let mut iter = map.iter();
+        assert_eq!(iter.next(), Some((0, 0)));
+        assert_eq!(iter.next_back(), Some((4, 40)));
+        assert_eq!(iter.next_back(), Some((3, 30)));
+        assert_eq!(iter.next(), Some((1, 10)));
+        assert_eq!(iter.next(), Some((2, 20)));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next_back(), None);
+        assert_eq!(iter.next_back(), None);
+
+        let mut iter = map.iter().rev();
+        assert_eq!(iter.next(), Some((4, 40)));
+        assert_eq!(iter.next_back(), Some((0, 0)));
+        assert_eq!(iter.next_back(), Some((1, 10)));
+        assert_eq!(iter.next(), Some((3, 30)));
+        assert_eq!(iter.next(), Some((2, 20)));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next_back(), None);
+        assert_eq!(iter.next_back(), None);
     }
 }

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -127,11 +127,10 @@ impl<T: IntoTryFromVal> Vec<T> {
     }
 
     #[inline(always)]
-    pub fn from_array<const N: usize>(env: &Env, elements: [T; N]) -> Vec<T> {
-        let obj = env.vec_new().in_env(env);
-        let mut vec = unsafe { Self::unchecked_new(obj) };
-        for e in elements {
-            vec.push(e);
+    pub fn from_array<const N: usize>(env: &Env, items: [T; N]) -> Vec<T> {
+        let mut vec = Vec::<T>::new(env);
+        for item in items {
+            vec.push(item);
         }
         vec
     }
@@ -259,7 +258,7 @@ impl<T: IntoTryFromVal> Vec<T> {
         T: IntoTryFromVal + Clone,
         T::Error: Debug,
     {
-        VecIter(self.clone())
+        self.clone().into_iter()
     }
 }
 
@@ -269,7 +268,6 @@ where
     T::Error: Debug,
 {
     type Item = T;
-
     type IntoIter = VecIter<T>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -277,6 +275,7 @@ where
     }
 }
 
+#[derive(Clone)]
 pub struct VecIter<T>(Vec<T>);
 
 impl<T> VecIter<T> {
@@ -448,6 +447,7 @@ mod test {
         assert_eq!(iter.next(), None);
 
         let vec = vec![&env, 0, 1, 2, 3, 4];
+
         let mut iter = vec.iter();
         assert_eq!(iter.next(), Some(0));
         assert_eq!(iter.next(), Some(1));
@@ -457,7 +457,6 @@ mod test {
         assert_eq!(iter.next(), None);
         assert_eq!(iter.next(), None);
 
-        let vec = vec![&env, 0, 1, 2, 3, 4];
         let mut iter = vec.iter();
         assert_eq!(iter.next(), Some(0));
         assert_eq!(iter.next_back(), Some(4));
@@ -469,7 +468,6 @@ mod test {
         assert_eq!(iter.next_back(), None);
         assert_eq!(iter.next_back(), None);
 
-        let vec = vec![&env, 0, 1, 2, 3, 4];
         let mut iter = vec.iter().rev();
         assert_eq!(iter.next(), Some(4));
         assert_eq!(iter.next_back(), Some(0));


### PR DESCRIPTION
### What

Add Map iterators, macro, and debug implementation.

### Why

To improve the ergonomics of using the Map type.

### Known limitations

I ended up implementing the iterators using the min and max only, and then deleting entries in the map during iteration. This is similar to the approach I took with Vec with slicing. I'm concerned that this will not be wise from a performance stand point, but I wanted to start here.

For both Map this has a benefit that can't be replicated with the existing host functions: It makes it possible to go from a partially consumed `MapIter` into a `Map`. It's a common pattern in Rust code to want to go from an iterator and collect into a type. If Map had a slice function similar to the Vec type, then we could replicate this without creating a new map on every iteration.

Also, one other thing I ran into is the `next` and `prev` host fns didn't seem to work as I expected. Everytime I called next or prev I kept getting back the same key I already had. I debugged for a while and I don't think it was the SDK code, but I could be wrong. In any case, I didn't end up needing them in the final version, so we may want to remove the next/prev keys. cc @jayz22 

I'm concerned that using min/max/del pattern in Map, and the slicing pattern in Vec, are not ideal from a resource usage point-of-view, but I wasn't sure because I guess we need to make this case affordable given that the Map type is immutable and it will be duplicated on every mutation anyway.

Either way I plan to try rewriting Vec to not to use the slice, and I'd be happy to rewrite the Map implementation if we can add a slice-like function to Maps and fix next and prev.