### PR TITLE
Add Vec,Map impls of FusedIterator,ExactSizeIterator,size_hint

### DIFF
--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -1,4 +1,4 @@
-use core::{cmp::Ordering, fmt::Debug, marker::PhantomData};
+use core::{cmp::Ordering, fmt::Debug, iter::FusedIterator, marker::PhantomData};
 
 use super::{
     env::internal::Env as _, xdr::ScObjectType, ConversionError, Env, EnvObj, EnvVal,
@@ -240,6 +240,13 @@ where
             V::try_from_val(env, value).unwrap(),
         ))
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.0.len() as usize;
+        (len, Some(len))
+    }
+
+    // TODO: Implement other functions as optimizations.
 }
 
 impl<K, V> DoubleEndedIterator for MapIter<K, V>
@@ -261,6 +268,29 @@ where
             K::try_from_val(env, key).unwrap(),
             V::try_from_val(env, value).unwrap(),
         ))
+    }
+
+    // TODO: Implement other functions as optimizations.
+}
+
+impl<K, V> FusedIterator for MapIter<K, V>
+where
+    K: IntoTryFromVal,
+    K::Error: Debug,
+    V: IntoTryFromVal,
+    V::Error: Debug,
+{
+}
+
+impl<K, V> ExactSizeIterator for MapIter<K, V>
+where
+    K: IntoTryFromVal,
+    K::Error: Debug,
+    V: IntoTryFromVal,
+    V::Error: Debug,
+{
+    fn len(&self) -> usize {
+        self.0.len() as usize
     }
 }
 

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -1,6 +1,7 @@
 use core::{
     cmp::Ordering,
     fmt::Debug,
+    iter::FusedIterator,
     marker::PhantomData,
     ops::{Bound, RangeBounds},
 };
@@ -310,6 +311,14 @@ where
             Some(item)
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.0.len() as usize;
+        (len, Some(len))
+    }
+
+    // TODO: Implement other functions as optimizations since the iterator is
+    // backed by an indexable collection.
 }
 
 impl<T> DoubleEndedIterator for VecIter<T>
@@ -326,6 +335,26 @@ where
             self.0 = self.0.slice(..len - 1);
             Some(item)
         }
+    }
+
+    // TODO: Implement other functions as optimizations since the iterator is
+    // backed by an indexable collection.
+}
+
+impl<T> FusedIterator for VecIter<T>
+where
+    T: IntoTryFromVal,
+    T::Error: Debug,
+{
+}
+
+impl<T> ExactSizeIterator for VecIter<T>
+where
+    T: IntoTryFromVal,
+    T::Error: Debug,
+{
+    fn len(&self) -> usize {
+        self.0.len() as usize
     }
 }
 

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -129,22 +129,17 @@ impl<T: IntoTryFromVal> Vec<T> {
     #[inline(always)]
     pub fn from_array<const N: usize>(env: &Env, items: [T; N]) -> Vec<T> {
         let mut vec = Vec::<T>::new(env);
-        for item in items {
-            vec.push(item);
-        }
+        vec.extend_from_array(items);
         vec
     }
 
     #[inline(always)]
-    pub fn from_slice(env: &Env, elements: &[T]) -> Vec<T>
+    pub fn from_slice(env: &Env, items: &[T]) -> Vec<T>
     where
         T: Clone,
     {
-        let obj = env.vec_new().in_env(env);
-        let mut vec = unsafe { Self::unchecked_new(obj) };
-        for e in elements {
-            vec.push(e.clone());
-        }
+        let mut vec = Vec::<T>::new(env);
+        vec.extend_from_slice(items);
         vec
     }
 
@@ -157,9 +152,6 @@ impl<T: IntoTryFromVal> Vec<T> {
         let val = env.vec_get(self.0.to_tagged(), i.into());
         T::try_from_val(env, val).unwrap()
     }
-
-    // TODO: Do we need to check_same_env for the env potentially stored in
-    // values of T? T values may be objects containing an Env?
 
     #[inline(always)]
     pub fn put(&mut self, i: u32, v: T) {
@@ -233,6 +225,23 @@ impl<T: IntoTryFromVal> Vec<T> {
         let env = self.env();
         let vec = env.vec_append(self.0.to_tagged(), other.0.to_tagged());
         self.0 = vec.in_env(env);
+    }
+
+    #[inline(always)]
+    pub fn extend_from_array<const N: usize>(&mut self, items: [T; N]) {
+        for item in items {
+            self.push(item);
+        }
+    }
+
+    #[inline(always)]
+    pub fn extend_from_slice(&mut self, items: &[T])
+    where
+        T: Clone,
+    {
+        for item in items {
+            self.push(item.clone());
+        }
     }
 
     #[must_use]

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -128,7 +128,7 @@ impl<T: IntoTryFromVal> Vec<T> {
 
     #[inline(always)]
     pub fn from_array<const N: usize>(env: &Env, items: [T; N]) -> Vec<T> {
-        let mut vec = Vec::<T>::new(env);
+        let mut vec = Vec::new(env);
         vec.extend_from_array(items);
         vec
     }
@@ -138,7 +138,7 @@ impl<T: IntoTryFromVal> Vec<T> {
     where
         T: Clone,
     {
-        let mut vec = Vec::<T>::new(env);
+        let mut vec = Vec::new(env);
         vec.extend_from_slice(items);
         vec
     }


### PR DESCRIPTION
### What

Add `Vec`,`Map` impls of `FusedIterator`,`ExactSizeIterator`,`size_hint`.

### Why

I was talking to folks on the Rust discord and they pointed out that the iterator should be fused if it guarantees to keep returning `None` once it returns `None` once. Also discovered we can implement some other traits and fns given the types of collections the iterators are for. 

### Known limitations

There are more fns we can implement as optimizations, but we probably don't need to do them now, so I wrote TODOs for those.