### PR TITLE
Rename Map has to contains_key

### DIFF
--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -134,7 +134,7 @@ impl<K: IntoTryFromVal, V: IntoTryFromVal> Map<K, V> {
     }
 
     #[inline(always)]
-    pub fn has(&self, k: K) -> bool {
+    pub fn contains_key(&self, k: K) -> bool {
         let env = self.env();
         let has = env.map_has(self.0.to_tagged(), k.into_val(env));
         bool::try_from_val(env, has).unwrap()


### PR DESCRIPTION
### What

Rename `Map` `has` to `contains_key`.

### Why

Consistency with other collection libs and std collections. Also it lends itself to adding a contains_value in the future.

### Known limitations

[TODO or N/A]
