### PR TITLE
Vec/Map accessors return Results: Consolidate Option and Result on accessors

### DIFF
--- a/macros/src/derive_type.rs
+++ b/macros/src/derive_type.rs
@@ -47,7 +47,6 @@ pub fn derive_type_struct(ident: &Ident, data: &DataStruct, spec: bool) -> Token
             let try_from = quote! {
                 #ident: map
                     .get(#map_key)
-                    .ok_or(ConversionError)? // TODO: Change this ConversionError into an error that indicates that the field is missing in the map.
                     .map_err(|_| ConversionError)?
                     .try_into()?
             };

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -110,6 +110,42 @@ impl<T: IntoTryFromVal> From<Vec<T>> for EnvObj {
     }
 }
 
+#[derive(Debug, Eq, PartialEq)]
+pub enum VecGetError<T>
+where
+    T: IntoTryFromVal,
+{
+    OutOfBounds,
+    ConversionError(T::Error),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum VecFirstError<T>
+where
+    T: IntoTryFromVal,
+{
+    Empty,
+    ConversionError(T::Error),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum VecLastError<T>
+where
+    T: IntoTryFromVal,
+{
+    Empty,
+    ConversionError(T::Error),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum VecPopError<T>
+where
+    T: IntoTryFromVal,
+{
+    Empty,
+    ConversionError(T::Error),
+}
+
 impl<T: IntoTryFromVal> Vec<T> {
     #[inline(always)]
     unsafe fn unchecked_new(obj: EnvObj) -> Self {
@@ -145,11 +181,12 @@ impl<T: IntoTryFromVal> Vec<T> {
     }
 
     #[inline(always)]
-    pub fn get(&self, i: u32) -> Option<Result<T, T::Error>> {
+    pub fn get(&self, i: u32) -> Result<T, VecGetError<T>> {
         if i < self.len() {
-            Some(self.get_unchecked(i))
+            self.get_unchecked(i)
+                .map_err(|e| VecGetError::ConversionError(e))
         } else {
-            None
+            Err(VecGetError::OutOfBounds)
         }
     }
 
@@ -204,11 +241,12 @@ impl<T: IntoTryFromVal> Vec<T> {
     }
 
     #[inline(always)]
-    pub fn pop(&mut self) -> Option<Result<T, T::Error>> {
+    pub fn pop(&mut self) -> Result<T, VecPopError<T>> {
         if self.is_empty() {
-            None
+            Err(VecPopError::Empty)
         } else {
-            Some(self.pop_unchecked())
+            self.pop_unchecked()
+                .map_err(|e| VecPopError::ConversionError(e))
         }
     }
 
@@ -222,11 +260,12 @@ impl<T: IntoTryFromVal> Vec<T> {
     }
 
     #[inline(always)]
-    pub fn first(&self) -> Option<Result<T, T::Error>> {
+    pub fn first(&self) -> Result<T, VecFirstError<T>> {
         if self.is_empty() {
-            None
+            Err(VecFirstError::Empty)
         } else {
-            Some(self.first_unchecked())
+            self.first_unchecked()
+                .map_err(|e| VecFirstError::ConversionError(e))
         }
     }
 
@@ -238,11 +277,12 @@ impl<T: IntoTryFromVal> Vec<T> {
     }
 
     #[inline(always)]
-    pub fn last(&self) -> Option<Result<T, T::Error>> {
+    pub fn last(&self) -> Result<T, VecLastError<T>> {
         if self.is_empty() {
-            None
+            Err(VecLastError::Empty)
         } else {
-            Some(self.last_unchecked())
+            self.last_unchecked()
+                .map_err(|e| VecLastError::ConversionError(e))
         }
     }
 


### PR DESCRIPTION
### What

Consolidate Option and Result on accessors in #201.

### Why

@jonjove suggested flattening the `Option<Result<>>` as it may improve ergonomics.

To my surprise this alternative resulted in the same sized WASM code as #201, even though #201 introduces no new state and #207 introduces new errors and has to map between them. I used the UDT example to test the WASM size as it uses the `Map::get` function.

### Known limitations

[TODO or N/A]
