### PR TITLE
Adapting ConversionError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-contract-env-common"
 version = "0.0.0"
+source = "git+https://github.com/jayz22/rs-stellar-contract-env?rev=b0aaa54#b0aaa54d0b2f4748f56d077ac00dada78306a48b"
 dependencies = [
  "static_assertions",
  "stellar-xdr",
@@ -632,6 +633,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-guest"
 version = "0.0.0"
+source = "git+https://github.com/jayz22/rs-stellar-contract-env?rev=b0aaa54#b0aaa54d0b2f4748f56d077ac00dada78306a48b"
 dependencies = [
  "stellar-contract-env-common",
 ]
@@ -639,6 +641,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-host"
 version = "0.0.0"
+source = "git+https://github.com/jayz22/rs-stellar-contract-env?rev=b0aaa54#b0aaa54d0b2f4748f56d077ac00dada78306a48b"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -656,7 +659,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-panic-handler-wasm32-unreachable"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=9afd00dd#9afd00dd25583564978b4ea472c99c6856e8a790"
+source = "git+https://github.com/jayz22/rs-stellar-contract-env?rev=b0aaa54#b0aaa54d0b2f4748f56d077ac00dada78306a48b"
 
 [[package]]
 name = "stellar-contract-macros"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,7 +624,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-contract-env-common"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=9afd00dd#9afd00dd25583564978b4ea472c99c6856e8a790"
 dependencies = [
  "static_assertions",
  "stellar-xdr",
@@ -633,7 +632,6 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-guest"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=9afd00dd#9afd00dd25583564978b4ea472c99c6856e8a790"
 dependencies = [
  "stellar-contract-env-common",
 ]
@@ -641,7 +639,6 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-host"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=9afd00dd#9afd00dd25583564978b4ea472c99c6856e8a790"
 dependencies = [
  "ed25519-dalek",
  "hex",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -16,13 +16,16 @@ stellar-contract-macros = { path = "../macros" }
 
 [target.'cfg(target_family="wasm")'.dependencies]
 stellar-contract-env-panic-handler-wasm32-unreachable = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "9afd00dd" }
-stellar-contract-env-guest = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "9afd00dd" }
-# stellar-contract-env-guest = { path = "../../rs-stellar-contract-env/stellar-contract-env-guest" }
+#stellar-contract-env-guest = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "9afd00dd" }
+stellar-contract-env-guest = { path = "../../rs-stellar-contract-env/stellar-contract-env-guest" }
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
-stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "9afd00dd" }
-# stellar-contract-env-host = { path = "../../rs-stellar-contract-env/stellar-contract-env-host" }
+#stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "9afd00dd" }
+stellar-contract-env-host = { path = "../../rs-stellar-contract-env/stellar-contract-env-host" }
 
 [dev-dependencies]
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "db2ca71", features = ["next", "std"] }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "db2ca71", features = [
+    "next",
+    "std",
+] }
 trybuild = "1.0.63"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -15,13 +15,13 @@ testutils = ["stellar-contract-env-host/testutils"]
 stellar-contract-macros = { path = "../macros" }
 
 [target.'cfg(target_family="wasm")'.dependencies]
-stellar-contract-env-panic-handler-wasm32-unreachable = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "9afd00dd" }
-#stellar-contract-env-guest = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "9afd00dd" }
-stellar-contract-env-guest = { path = "../../rs-stellar-contract-env/stellar-contract-env-guest" }
+stellar-contract-env-panic-handler-wasm32-unreachable = { git = "https://github.com/jayz22/rs-stellar-contract-env", rev = "b0aaa54" }
+stellar-contract-env-guest = { git = "https://github.com/jayz22/rs-stellar-contract-env", rev = "b0aaa54" }
+# stellar-contract-env-guest = { path = "../../rs-stellar-contract-env/stellar-contract-env-guest" }
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
-#stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "9afd00dd" }
-stellar-contract-env-host = { path = "../../rs-stellar-contract-env/stellar-contract-env-host" }
+stellar-contract-env-host = { git = "https://github.com/jayz22/rs-stellar-contract-env", rev = "b0aaa54" }
+# stellar-contract-env-host = { path = "../../rs-stellar-contract-env/stellar-contract-env-host" }
 
 [dev-dependencies]
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "db2ca71", features = [

--- a/sdk/src/bigint.rs
+++ b/sdk/src/bigint.rs
@@ -14,29 +14,29 @@ use super::{
 pub struct BigInt(EnvObj);
 
 impl TryFrom<EnvVal> for BigInt {
-    type Error = ConversionError<EnvVal, BigInt>;
+    type Error = ConversionError<BigInt>;
 
     fn try_from(ev: EnvVal) -> Result<Self, Self::Error> {
         let obj: EnvObj = ev.clone().try_into().map_err(|_| Self::Error {
-            from: PhantomData,
+            from: ev.to_raw(),
             to: PhantomData,
         })?;
-        obj.try_into().map_err(|_| Self::Error {
-            from: PhantomData,
+        obj.clone().try_into().map_err(|_| Self::Error {
+            from: obj.to_raw(),
             to: PhantomData,
         })
     }
 }
 
 impl TryFrom<EnvObj> for BigInt {
-    type Error = ConversionError<EnvObj, BigInt>;
+    type Error = ConversionError<BigInt>;
 
     fn try_from(obj: EnvObj) -> Result<Self, Self::Error> {
         if obj.as_tagged().is_obj_type(ScObjectType::BigInt) {
             Ok(BigInt(obj))
         } else {
             Err(Self::Error {
-                from: PhantomData,
+                from: obj.to_raw(),
                 to: PhantomData,
             })
         }

--- a/sdk/src/bigint.rs
+++ b/sdk/src/bigint.rs
@@ -1,5 +1,6 @@
 use core::{
     cmp::Ordering,
+    marker::PhantomData,
     ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Not, Rem, Shl, Shr, Sub},
 };
 
@@ -9,26 +10,35 @@ use super::{
 };
 
 #[repr(transparent)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BigInt(EnvObj);
 
 impl TryFrom<EnvVal> for BigInt {
-    type Error = ConversionError;
+    type Error = ConversionError<EnvVal, BigInt>;
 
     fn try_from(ev: EnvVal) -> Result<Self, Self::Error> {
-        let obj: EnvObj = ev.clone().try_into()?;
-        obj.try_into()
+        let obj: EnvObj = ev.clone().try_into().map_err(|_| Self::Error {
+            from: PhantomData,
+            to: PhantomData,
+        })?;
+        obj.try_into().map_err(|_| Self::Error {
+            from: PhantomData,
+            to: PhantomData,
+        })
     }
 }
 
 impl TryFrom<EnvObj> for BigInt {
-    type Error = ConversionError;
+    type Error = ConversionError<EnvObj, BigInt>;
 
     fn try_from(obj: EnvObj) -> Result<Self, Self::Error> {
         if obj.as_tagged().is_obj_type(ScObjectType::BigInt) {
             Ok(BigInt(obj))
         } else {
-            Err(ConversionError {})
+            Err(Self::Error {
+                from: PhantomData,
+                to: PhantomData,
+            })
         }
     }
 }

--- a/sdk/src/binary.rs
+++ b/sdk/src/binary.rs
@@ -56,23 +56,23 @@ impl Ord for Binary {
 }
 
 impl TryFrom<EnvVal> for Binary {
-    type Error = ConversionError<EnvVal, Binary>;
+    type Error = ConversionError<Binary>;
 
     #[inline(always)]
     fn try_from(ev: EnvVal) -> Result<Self, Self::Error> {
-        let obj: EnvObj = ev.try_into().map_err(|_| Self::Error {
-            from: PhantomData,
+        let obj: EnvObj = ev.clone().try_into().map_err(|_| Self::Error {
+            from: ev.to_raw(),
             to: PhantomData,
         })?;
         obj.try_into().map_err(|_| Self::Error {
-            from: PhantomData,
+            from: ev.to_raw(),
             to: PhantomData,
         })
     }
 }
 
 impl TryFrom<EnvObj> for Binary {
-    type Error = ConversionError<EnvObj, Binary>;
+    type Error = ConversionError<Binary>;
 
     #[inline(always)]
     fn try_from(obj: EnvObj) -> Result<Self, Self::Error> {
@@ -80,7 +80,7 @@ impl TryFrom<EnvObj> for Binary {
             Ok(unsafe { Binary::unchecked_new(obj) })
         } else {
             Err(Self::Error {
-                from: PhantomData,
+                from: obj.to_raw(),
                 to: PhantomData,
             })
         }
@@ -268,39 +268,39 @@ impl<const N: u32> FixedLengthBinary for ArrayBinary<N> {
 }
 
 impl<const N: u32> TryFrom<EnvVal> for ArrayBinary<N> {
-    type Error = ConversionError<EnvVal, ArrayBinary<N>>;
+    type Error = ConversionError<ArrayBinary<N>>;
 
     #[inline(always)]
     fn try_from(ev: EnvVal) -> Result<Self, Self::Error> {
-        let obj: EnvObj = ev.try_into().map_err(|_| Self::Error {
-            from: PhantomData,
+        let obj: EnvObj = ev.clone().try_into().map_err(|_| Self::Error {
+            from: ev.to_raw(),
             to: PhantomData,
         })?;
-        obj.try_into().map_err(|_| Self::Error {
-            from: PhantomData,
+        obj.clone().try_into().map_err(|_| Self::Error {
+            from: obj.to_raw(),
             to: PhantomData,
         })
     }
 }
 
 impl<const N: u32> TryFrom<EnvObj> for ArrayBinary<N> {
-    type Error = ConversionError<EnvObj, ArrayBinary<N>>;
+    type Error = ConversionError<ArrayBinary<N>>;
 
     #[inline(always)]
     fn try_from(obj: EnvObj) -> Result<Self, Self::Error> {
-        let bin: Binary = obj.try_into().map_err(|_| Self::Error {
-            from: PhantomData,
+        let bin: Binary = obj.clone().try_into().map_err(|_| Self::Error {
+            from: obj.to_raw(),
             to: PhantomData,
         })?;
         bin.try_into().map_err(|_| Self::Error {
-            from: PhantomData,
+            from: obj.to_raw(),
             to: PhantomData,
         })
     }
 }
 
 impl<const N: u32> TryFrom<Binary> for ArrayBinary<N> {
-    type Error = ConversionError<Binary, ArrayBinary<N>>;
+    type Error = ConversionError<ArrayBinary<N>>;
 
     #[inline(always)]
     fn try_from(bin: Binary) -> Result<Self, Self::Error> {
@@ -308,7 +308,7 @@ impl<const N: u32> TryFrom<Binary> for ArrayBinary<N> {
             Ok(Self(bin))
         } else {
             Err(Self::Error {
-                from: PhantomData,
+                from: bin.0.to_raw(),
                 to: PhantomData,
             })
         }
@@ -376,8 +376,7 @@ mod test {
         bin_copy.pop();
         assert!(bin == bin_copy);
 
-        let bad_fixed: Result<ArrayBinary<4>, ConversionError<Binary, ArrayBinary<4>>> =
-            bin.try_into();
+        let bad_fixed: Result<ArrayBinary<4>, ConversionError<ArrayBinary<4>>> = bin.try_into();
         assert!(!bad_fixed.is_ok());
         let _fixed: ArrayBinary<3> = bin_copy.try_into().unwrap();
     }

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -38,7 +38,7 @@ pub type EnvObj = internal::EnvVal<Env, Object>;
 pub trait IntoTryFromVal: IntoVal<Env, RawVal> + TryFromVal<Env, RawVal> {}
 impl<C> IntoTryFromVal for C where C: IntoVal<Env, RawVal> + TryFromVal<Env, RawVal> {}
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct Env {
     env_impl: internal::EnvImpl,
 }

--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -76,23 +76,23 @@ impl<K: IntoTryFromVal, V: IntoTryFromVal> TryFrom<EnvVal> for Map<K, V>
 where
     K::Error: Debug,
 {
-    type Error = ConversionError<EnvVal, Map<K, V>>;
+    type Error = ConversionError<Map<K, V>>;
 
     #[inline(always)]
     fn try_from(ev: EnvVal) -> Result<Self, Self::Error> {
-        let obj: EnvObj = ev.try_into().map_err(|_| Self::Error {
-            from: PhantomData,
+        let obj: EnvObj = ev.clone().try_into().map_err(|_| Self::Error {
+            from: ev.to_raw(),
             to: PhantomData,
         })?;
-        obj.try_into().map_err(|_| Self::Error {
-            from: PhantomData,
+        obj.clone().try_into().map_err(|_| Self::Error {
+            from: obj.to_raw(),
             to: PhantomData,
         })
     }
 }
 
 impl<K: IntoTryFromVal, V: IntoTryFromVal> TryFrom<EnvObj> for Map<K, V> {
-    type Error = ConversionError<EnvObj, Map<K, V>>;
+    type Error = ConversionError<Map<K, V>>;
 
     #[inline(always)]
     fn try_from(obj: EnvObj) -> Result<Self, Self::Error> {
@@ -100,7 +100,7 @@ impl<K: IntoTryFromVal, V: IntoTryFromVal> TryFrom<EnvObj> for Map<K, V> {
             Ok(Map(obj, PhantomData, PhantomData))
         } else {
             Err(Self::Error {
-                from: PhantomData,
+                from: obj.to_raw(),
                 to: PhantomData,
             })
         }

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -68,23 +68,23 @@ where
 }
 
 impl<T: IntoTryFromVal> TryFrom<EnvVal> for Vec<T> {
-    type Error = ConversionError<EnvVal, Vec<T>>;
+    type Error = ConversionError<Vec<T>>;
 
     #[inline(always)]
     fn try_from(ev: EnvVal) -> Result<Self, Self::Error> {
-        let obj: EnvObj = ev.try_into().map_err(|_| Self::Error {
-            from: PhantomData,
+        let obj: EnvObj = ev.clone().try_into().map_err(|_| Self::Error {
+            from: ev.to_raw(),
             to: PhantomData,
         })?;
-        obj.try_into().map_err(|_| Self::Error {
-            from: PhantomData,
+        obj.clone().try_into().map_err(|_| Self::Error {
+            from: obj.to_raw(),
             to: PhantomData,
         })
     }
 }
 
 impl<T: IntoTryFromVal> TryFrom<EnvObj> for Vec<T> {
-    type Error = ConversionError<EnvObj, Vec<T>>;
+    type Error = ConversionError<Vec<T>>;
 
     #[inline(always)]
     fn try_from(obj: EnvObj) -> Result<Self, Self::Error> {
@@ -92,7 +92,7 @@ impl<T: IntoTryFromVal> TryFrom<EnvObj> for Vec<T> {
             Ok(unsafe { Vec::<T>::unchecked_new(obj) })
         } else {
             Err(Self::Error {
-                from: PhantomData,
+                from: obj.to_raw(),
                 to: PhantomData,
             })
         }

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -68,24 +68,33 @@ where
 }
 
 impl<T: IntoTryFromVal> TryFrom<EnvVal> for Vec<T> {
-    type Error = ConversionError;
+    type Error = ConversionError<EnvVal, Vec<T>>;
 
     #[inline(always)]
     fn try_from(ev: EnvVal) -> Result<Self, Self::Error> {
-        let obj: EnvObj = ev.try_into()?;
-        obj.try_into()
+        let obj: EnvObj = ev.try_into().map_err(|_| Self::Error {
+            from: PhantomData,
+            to: PhantomData,
+        })?;
+        obj.try_into().map_err(|_| Self::Error {
+            from: PhantomData,
+            to: PhantomData,
+        })
     }
 }
 
 impl<T: IntoTryFromVal> TryFrom<EnvObj> for Vec<T> {
-    type Error = ConversionError;
+    type Error = ConversionError<EnvObj, Vec<T>>;
 
     #[inline(always)]
     fn try_from(obj: EnvObj) -> Result<Self, Self::Error> {
         if obj.as_tagged().is_obj_type(ScObjectType::Vec) {
             Ok(unsafe { Vec::<T>::unchecked_new(obj) })
         } else {
-            Err(ConversionError {})
+            Err(Self::Error {
+                from: PhantomData,
+                to: PhantomData,
+            })
         }
     }
 }

--- a/sdk/tests/macros_spec_udt.rs
+++ b/sdk/tests/macros_spec_udt.rs
@@ -1,4 +1,4 @@
-use std::io::Cursor;
+use std::{io::Cursor, marker::PhantomData};
 
 use stellar_contract_sdk::{
     contractfn, ConversionError, Env, EnvVal, IntoEnvVal, IntoVal, RawVal, TryFromVal,
@@ -15,10 +15,13 @@ pub struct Udt {
 }
 
 impl TryFrom<EnvVal> for Udt {
-    type Error = ConversionError;
+    type Error = ConversionError<Udt>;
 
     fn try_from(ev: EnvVal) -> Result<Self, Self::Error> {
-        let (a, b): (i32, i32) = ev.try_into()?;
+        let (a, b): (i32, i32) = ev.clone().try_into().map_err(|_| Self::Error {
+            from: ev.to_raw(),
+            to: PhantomData,
+        })?;
         Ok(Udt { a, b })
     }
 }


### PR DESCRIPTION
### What

Adapting to changes in: https://github.com/stellar/rs-stellar-contract-env/pull/181

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

One place still breaking. 

```
error[E0423]: expected value, found struct `ConversionError`
  --> examples/udt/src/lib.rs:12:1
   |
12 | #[contracttype]
   | ^^^^^^^^^^^^^^^ help: use struct literal syntax instead: `ConversionError { from: val, to: val }`
   |
  ::: /Users/jay/Documents/Github/rs-stellar-contract-env/stellar-contract-env-common/src/raw_val.rs:64:1
   |
64 | pub struct ConversionError<T> {
   | ----------------------------- `ConversionError` defined here
   |
   = note: this error originates in the derive macro `stellar_contract_sdk::ContractType` (in Nightly builds, run with -Z macro-backtrace for more info)
```
@leighmcculloch Do you have any idea about this error? 