### PR TITLE
Use the toolchain file in GitHub CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: rustup update stable && rustup default stable
+    - run: rustup update
     - run: find . -type f -name '*.rs' -print0 | xargs -I {} -0 rustfmt --check "{}"
 
   build-and-test:
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+    - run: rustup update
     - run: cargo install --locked --version 0.5.14 cargo-hack
     - run: cargo check --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }} --lib
     - if: matrix.sys.test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,8 +53,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
-      with:
-        default: true
     - run: cargo install --locked --version 0.5.14 cargo-hack
     - run: cargo check --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }} --lib
     - if: matrix.sys.test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,10 +54,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
       with:
-        toolchain: stable
         default: true
-        components: rustfmt, clippy
-        target: ${{ matrix.sys.target }}
     - run: cargo install --locked --version 0.5.14 cargo-hack
     - run: cargo check --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }} --lib
     - if: matrix.sys.test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,6 +53,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
+    - run: rustup target add ${{ matrix.sys.target }}
     - run: cargo install --locked --version 0.5.14 cargo-hack
     - run: cargo check --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }} --lib
     - if: matrix.sys.test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
-    - run: find . -type f -name '*.rs' -print0 | xargs -I {} -0 rustfmt --check "{}"
+    - run: cargo fmt --all --check
 
   build-and-test:
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'
 
 fmt:
-	rustfmt $$(find . -type f -name '*.rs' -print)
+	cargo fmt --all
 
 clean:
 	cargo clean


### PR DESCRIPTION
### What

Use the toolchain file in GitHub Actions.

### Why

There's no reason to respecify values that are included already in the toolchain file since the action will load them from there.

### Known limitations

[TODO or N/A]
