### PR TITLE
Union discriminant encode as Symbol instead of u32

### DIFF
--- a/examples/udt/src/lib.rs
+++ b/examples/udt/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
-use stellar_contract_sdk::{
-    contractfn, contracttype, ConversionError, Env, EnvVal, IntoEnvVal, RawVal,
-};
+use stellar_contract_sdk::{contractfn, contracttype, ConversionError, IntoEnvVal};
 
 #[contracttype]
 pub enum UdtEnum {


### PR DESCRIPTION
### What

Union discriminant encode as Symbol instead of u32.

### Why

To make the encoded value more self-descriptive and resilient to changes such as inserting new enum values into earlier positions in the enum.

Close #218

### Known limitations

This increased the UDT example by about 50 bytes.
