### PR TITLE
Remove contractfn macro

### DIFF
--- a/examples/add_i32/src/lib.rs
+++ b/examples/add_i32/src/lib.rs
@@ -1,9 +1,13 @@
 #![no_std]
-use stellar_contract_sdk::contractfn;
+use stellar_contract_sdk::contractimpl;
 
-#[contractfn]
-pub fn add(a: i32, b: i32) -> i32 {
-    a + b
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn add(a: i32, b: i32) -> i32 {
+        a + b
+    }
 }
 
 #[cfg(test)]

--- a/examples/add_i64/src/lib.rs
+++ b/examples/add_i64/src/lib.rs
@@ -1,82 +1,69 @@
 #![no_std]
-use stellar_contract_sdk::Env;
-use stellar_contract_sdk::{contractfn, contractimpl};
+use stellar_contract_sdk::{contractimpl, Env};
 
-// There are three ways to export contract fns:
+// There are two ways to export contract fns:
 
-// 1. Using the `contractfn` macro on a module fn.
+// 1. Using the `contractimpl` macro on a struct impl.
 
-#[contractfn]
-pub fn add(a: i64, b: i64) -> i64 {
-    a + b
-}
-
-// 2. Using the `contractimpl` macro on a struct impl.
-
-pub struct Add2;
+pub struct Add1;
 
 #[contractimpl]
-impl Add2 {
+impl Add1 {
     fn addimpl(a: i64, b: i64) -> i64 {
         a + b
     }
-    pub fn add2(a: i64, b: i64) -> i64 {
+    pub fn add1(a: i64, b: i64) -> i64 {
         Self::addimpl(a, b)
     }
 }
 
-// 3. Using the `contractimpl` macro on a trait impl.
+// 2. Using the `contractimpl` macro on a trait impl.
 
-pub trait Add3Trait {
-    fn add3(e: Env, a: i64, b: i64) -> i64;
+pub trait Add2Trait {
+    fn add2(e: Env, a: i64, b: i64) -> i64;
 }
 
-pub struct Add3;
+pub struct Add2;
 
 #[contractimpl]
-impl Add3Trait for Add3 {
-    fn add3(_e: Env, a: i64, b: i64) -> i64 {
+impl Add2Trait for Add2 {
+    fn add2(_e: Env, a: i64, b: i64) -> i64 {
         a + b
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::{add, Add2, Add3, Add3Trait};
+    use super::{Add1, Add2, Add2Trait};
     use stellar_contract_sdk::Env;
 
     #[test]
     fn test_add() {
-        [add, Add2::add2].iter().for_each(|f| {
-            let x = 10i64;
-            let y = 12i64;
-            let z = f(x, y);
-            assert_eq!(z, 22);
-        });
-        [Add3::add3].iter().for_each(|f| {
-            let e = Env::default();
-            let x = 10i64;
-            let y = 12i64;
-            let z = f(e, x, y);
-            assert_eq!(z, 22);
-        });
+        let x = 10i64;
+        let y = 12i64;
+        let z = Add1::add1(x, y);
+        assert_eq!(z, 22);
+
+        let e = Env::default();
+        let z = Add2::add2(e, x, y);
+        assert_eq!(z, 22);
     }
 }
 
 #[cfg(test)]
 mod test_via_val {
-    use super::{__add, __add2, __add3};
+    use super::{__add1, __add2};
     use stellar_contract_sdk::{Env, IntoVal, TryFromVal};
 
     #[test]
     fn test_add_val() {
-        [__add, __add2, __add3].iter().for_each(|f| {
+        for f in [__add1, __add2] {
             let e = Env::default();
             let x = 10i64.into_val(&e);
             let y = 12i64.into_val(&e);
             let z = f(e.clone(), x, y);
             let z = i64::try_from_val(&e, z).unwrap();
             assert_eq!(z, 22);
-        });
+        }
     }
 }

--- a/examples/contract_data/src/lib.rs
+++ b/examples/contract_data/src/lib.rs
@@ -1,12 +1,15 @@
 #![no_std]
-use stellar_contract_sdk::{contractfn, Env, Symbol};
+use stellar_contract_sdk::{contractimpl, Env, Symbol};
 
-#[contractfn]
-pub fn put(e: Env, key: Symbol, val: Symbol) {
-    e.put_contract_data(key, val)
-}
+pub struct Contract;
 
-#[contractfn]
-pub fn del(e: Env, key: Symbol) {
-    e.del_contract_data(key)
+#[contractimpl]
+impl Contract {
+    pub fn put(e: Env, key: Symbol, val: Symbol) {
+        e.put_contract_data(key, val)
+    }
+
+    pub fn del(e: Env, key: Symbol) {
+        e.del_contract_data(key)
+    }
 }

--- a/examples/create_contract/src/lib.rs
+++ b/examples/create_contract/src/lib.rs
@@ -1,9 +1,13 @@
 #![no_std]
-use stellar_contract_sdk::{contractfn, Binary, Env};
+use stellar_contract_sdk::{contractimpl, Binary, Env};
 
-// Note that anyone can create a contract here with any salt, so a users call to
-// this could be frontrun and the same salt taken.
-#[contractfn]
-pub fn create(e: Env, c: Binary, s: Binary) {
-    e.create_contract_using_parent_id(c, s)
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    // Note that anyone can create a contract here with any salt, so a users call to
+    // this could be frontrun and the same salt taken.
+    pub fn create(e: Env, c: Binary, s: Binary) {
+        e.create_contract_using_parent_id(c, s);
+    }
 }

--- a/examples/linear_memory/src/lib.rs
+++ b/examples/linear_memory/src/lib.rs
@@ -1,27 +1,29 @@
 #![no_std]
-use stellar_contract_sdk::{contractfn, Binary, Env, FixedLengthBinary};
+use stellar_contract_sdk::{contractimpl, Binary, Env, FixedLengthBinary};
 
-#[contractfn]
-pub fn bin_new(e: Env, len: u32) -> Binary {
-    let buf: [u8; 4] = [0, 1, 2, 3];
-    e.binary_new_from_linear_memory(buf.as_ptr() as u32, len)
-}
+pub struct Contract;
 
-#[contractfn]
-pub fn from_guest(e: Env, b: Binary, b_pos: u32, lm_pos: u32, len: u32) -> Binary {
-    let buf: [u8; 4] = [0, 1, 2, 3];
-    assert!(lm_pos + len > buf.len() as u32);
-    let lm_pos: u32 = unsafe { buf.as_ptr().add(lm_pos as usize) as u32 };
-    e.binary_copy_from_linear_memory(b, b_pos, lm_pos, len)
-}
+#[contractimpl]
+impl Contract {
+    pub fn bin_new(e: Env, len: u32) -> Binary {
+        let buf: [u8; 4] = [0, 1, 2, 3];
+        e.binary_new_from_linear_memory(buf.as_ptr() as u32, len)
+    }
 
-#[contractfn]
-pub fn to_guest(e: Env, b: Binary, b_pos: u32, lm_pos: u32, len: u32) {
-    let buf: [u8; 4] = [0; 4];
-    assert!(lm_pos + len > buf.len() as u32);
-    let lm_pos: u32 = unsafe { buf.as_ptr().add(lm_pos as usize) as u32 };
-    e.binary_copy_to_linear_memory(b.clone(), b_pos, lm_pos, len);
-    for idx in lm_pos..buf.len() as u32 {
-        assert_eq!(buf[idx as usize], b.get(b_pos + idx));
+    pub fn from_guest(e: Env, b: Binary, b_pos: u32, lm_pos: u32, len: u32) -> Binary {
+        let buf: [u8; 4] = [0, 1, 2, 3];
+        assert!(lm_pos + len > buf.len() as u32);
+        let lm_pos: u32 = unsafe { buf.as_ptr().add(lm_pos as usize) as u32 };
+        e.binary_copy_from_linear_memory(b, b_pos, lm_pos, len)
+    }
+
+    pub fn to_guest(e: Env, b: Binary, b_pos: u32, lm_pos: u32, len: u32) {
+        let buf: [u8; 4] = [0; 4];
+        assert!(lm_pos + len > buf.len() as u32);
+        let lm_pos: u32 = unsafe { buf.as_ptr().add(lm_pos as usize) as u32 };
+        e.binary_copy_to_linear_memory(b.clone(), b_pos, lm_pos, len);
+        for idx in lm_pos..buf.len() as u32 {
+            assert_eq!(buf[idx as usize], b.get(b_pos + idx));
+        }
     }
 }

--- a/examples/udt/src/lib.rs
+++ b/examples/udt/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use stellar_contract_sdk::{contractfn, contracttype, ConversionError, IntoEnvVal};
+use stellar_contract_sdk::{contractimpl, contracttype, ConversionError, IntoEnvVal};
 
 #[contracttype]
 pub enum UdtEnum {
@@ -13,17 +13,21 @@ pub struct UdtStruct {
     pub b: i64,
 }
 
-#[contractfn]
-pub fn add(a: UdtEnum, b: UdtEnum) -> i64 {
-    let a = match a {
-        UdtEnum::UdtA => 0,
-        UdtEnum::UdtB(udt) => udt.a + udt.b,
-    };
-    let b = match b {
-        UdtEnum::UdtA => 0,
-        UdtEnum::UdtB(udt) => udt.a + udt.b,
-    };
-    a + b
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn add(a: UdtEnum, b: UdtEnum) -> i64 {
+        let a = match a {
+            UdtEnum::UdtA => 0,
+            UdtEnum::UdtB(udt) => udt.a + udt.b,
+        };
+        let b = match b {
+            UdtEnum::UdtA => 0,
+            UdtEnum::UdtB(udt) => udt.a + udt.b,
+        };
+        a + b
+    }
 }
 
 #[cfg(test)]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -10,27 +10,8 @@ use derive_type::{derive_type_enum, derive_type_struct};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
-    parse_macro_input, spanned::Spanned, DeriveInput, Error, ImplItem, ItemFn, ItemImpl, Visibility,
+    parse_macro_input, spanned::Spanned, DeriveInput, Error, ImplItem, ItemImpl, Visibility,
 };
-
-#[proc_macro_attribute]
-pub fn contractfn(_metadata: TokenStream, input: TokenStream) -> TokenStream {
-    let mut errors = Vec::<Error>::new();
-    let func = parse_macro_input!(input as ItemFn);
-    if !matches!(func.vis, Visibility::Public(_)) {
-        errors.push(Error::new(func.span(), "contract functions must be public"));
-    }
-    let ident = &func.sig.ident;
-    let call = quote! { #ident };
-    let derived = derive_fn(&call, ident, &func.sig.inputs, &func.sig.output);
-    let compile_errors = errors.iter().map(Error::to_compile_error);
-    quote! {
-        #func
-        #(#compile_errors)*
-        #derived
-    }
-    .into()
-}
 
 #[proc_macro_attribute]
 pub fn contractimpl(_metadata: TokenStream, input: TokenStream) -> TokenStream {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -8,7 +8,7 @@
 #[cfg(target_family = "wasm")]
 use stellar_contract_env_panic_handler_wasm32_unreachable as _;
 
-pub use stellar_contract_macros::{contractfn, contractimpl, contracttype, ContractType};
+pub use stellar_contract_macros::{contractimpl, contracttype, ContractType};
 
 mod env;
 pub use env::xdr;

--- a/sdk/tests/macros_fails/macros_spec_i32.rs
+++ b/sdk/tests/macros_fails/macros_spec_i32.rs
@@ -1,10 +1,14 @@
-use stellar_contract_sdk::contractfn;
+use stellar_contract_sdk::contractimpl;
 
 pub struct MyType<A>(pub A);
 
-#[contractfn]
-pub fn add(a: MyType<i32>, b: MyType<i32>) -> i8 {
-    unimplemented!()
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn add(a: MyType<i32>, b: MyType<i32>) -> i8 {
+        unimplemented!()
+    }
 }
 
 pub fn main() {}

--- a/sdk/tests/macros_fails/macros_spec_i32.stderr
+++ b/sdk/tests/macros_fails/macros_spec_i32.stderr
@@ -1,11 +1,11 @@
 error: generics unsupported on user-defined types in contract functions
- --> tests/macros_fails/macros_spec_i32.rs:6:21
+ --> tests/macros_fails/macros_spec_i32.rs:9:25
   |
-6 | pub fn add(a: MyType<i32>, b: MyType<i32>) -> i8 {
-  |                     ^
+9 |     pub fn add(a: MyType<i32>, b: MyType<i32>) -> i8 {
+  |                         ^
 
 error: generics unsupported on user-defined types in contract functions
- --> tests/macros_fails/macros_spec_i32.rs:6:37
+ --> tests/macros_fails/macros_spec_i32.rs:9:41
   |
-6 | pub fn add(a: MyType<i32>, b: MyType<i32>) -> i8 {
-  |                                     ^
+9 |     pub fn add(a: MyType<i32>, b: MyType<i32>) -> i8 {
+  |                                         ^

--- a/sdk/tests/macros_fails/macros_spec_non_pub_fn.rs
+++ b/sdk/tests/macros_fails/macros_spec_non_pub_fn.rs
@@ -1,8 +1,0 @@
-use stellar_contract_sdk::contractfn;
-
-#[contractfn]
-fn add(a: i32, b: i32) -> i32 {
-    unimplemented!()
-}
-
-pub fn main() {}

--- a/sdk/tests/macros_fails/macros_spec_non_pub_fn.stderr
+++ b/sdk/tests/macros_fails/macros_spec_non_pub_fn.stderr
@@ -1,5 +1,0 @@
-error: contract functions must be public
- --> tests/macros_fails/macros_spec_non_pub_fn.rs:4:1
-  |
-4 | fn add(a: i32, b: i32) -> i32 {
-  | ^^

--- a/sdk/tests/macros_spec_i32.rs
+++ b/sdk/tests/macros_spec_i32.rs
@@ -1,11 +1,15 @@
 use std::io::Cursor;
 
-use stellar_contract_sdk::{contractfn, Env, IntoVal, TryFromVal};
+use stellar_contract_sdk::{contractimpl, Env, IntoVal, TryFromVal};
 use stellar_xdr::{ReadXdr, SpecEntry, SpecEntryFunction, SpecEntryFunctionV0, SpecTypeDef};
 
-#[contractfn]
-pub fn add(a: i32, b: i32) -> i32 {
-    a + b
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn add(a: i32, b: i32) -> i32 {
+        a + b
+    }
 }
 
 #[test]

--- a/sdk/tests/macros_spec_udt.rs
+++ b/sdk/tests/macros_spec_udt.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 
 use stellar_contract_sdk::{
-    contractfn, ConversionError, Env, EnvVal, IntoEnvVal, IntoVal, RawVal, TryFromVal,
+    contractimpl, ConversionError, Env, EnvVal, IntoEnvVal, IntoVal, RawVal, TryFromVal,
 };
 use stellar_xdr::{
     ReadXdr, SpecEntry, SpecEntryFunction, SpecEntryFunctionV0, SpecTypeDef, SpecTypeTuple,
@@ -29,9 +29,13 @@ impl IntoEnvVal<Env, RawVal> for Udt {
     }
 }
 
-#[contractfn]
-pub fn add(a: Udt, b: Udt) -> (Udt, Udt) {
-    (a, b)
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn add(a: Udt, b: Udt) -> (Udt, Udt) {
+        (a, b)
+    }
 }
 
 #[test]


### PR DESCRIPTION
### What
Remove contractfn macro.

### Why

It's causing some confusion because we don't hope people will continue to use it, but most of the examples use it.

Close #225

### Known limitations

[TODO or N/A]
