### PR TITLE
Shift fns around in TestContract and Env

### DIFF
--- a/sdk/src/test_contract.rs
+++ b/sdk/src/test_contract.rs
@@ -2,10 +2,9 @@
 
 use crate::env::{
     internal::{ContractFunctionSet, EnvImpl},
-    Env, Object, RawVal, Symbol,
+    Env, RawVal, Symbol,
 };
 use std::collections::HashMap;
-use std::rc::Rc;
 
 pub struct TestContract(HashMap<Symbol, &'static dyn Fn(Env, &[RawVal]) -> RawVal>);
 
@@ -17,23 +16,11 @@ impl TestContract {
     pub fn add_function(&mut self, name: &str, f: &'static dyn Fn(Env, &[RawVal]) -> RawVal) {
         self.0.insert(Symbol::from_str(name), f);
     }
-
-    pub fn register(self, e: &Env, contract_id: RawVal) {
-        let id_obj: Object = RawVal::from(contract_id).try_into().unwrap();
-        e.env_impl
-            .register_test_contract(id_obj, Rc::new(self))
-            .unwrap();
-    }
 }
 
 impl ContractFunctionSet for TestContract {
     fn call(&self, func: &Symbol, env_impl: &EnvImpl, args: &[RawVal]) -> Option<RawVal> {
         let f = self.0.get(func)?;
-        Some(f(
-            Env {
-                env_impl: env_impl.clone(),
-            },
-            args,
-        ))
+        Some(f(Env::with_impl(env_impl.clone()), args))
     }
 }

--- a/sdk/src/test_contract.rs
+++ b/sdk/src/test_contract.rs
@@ -21,6 +21,7 @@ impl TestContract {
 impl ContractFunctionSet for TestContract {
     fn call(&self, func: &Symbol, env_impl: &EnvImpl, args: &[RawVal]) -> Option<RawVal> {
         let f = self.0.get(func)?;
-        Some(f(Env::with_impl(env_impl.clone()), args))
+        let env = Env::with_impl(env_impl.clone());
+        Some(f(env, args))
     }
 }


### PR DESCRIPTION
### What

Move the `TestContract::register` fn to `Env`. Organize testutils fns so they are bundled in their own `Env` impl.

### Why

The register fn is wrapping calling the Env internals. Instead of the user using the TestContract to do registration, they should just use the Env to do registration, since the Env is the one who provides that functionality.

Bundling the testutils fns together helps as this file goes to be able to digest the related sets of fns.

### Known limitations

[TODO or N/A]
