### PR TITLE
Expose the "require" function, use in place of assert!() in example.

### DIFF
--- a/examples/linear_memory/src/lib.rs
+++ b/examples/linear_memory/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use stellar_contract_sdk::{contractimpl, Binary, Env, FixedLengthBinary};
+use stellar_contract_sdk::{contractimpl, require, Binary, Env, FixedLengthBinary};
 
 pub struct Contract;
 
@@ -12,18 +12,18 @@ impl Contract {
 
     pub fn from_guest(e: Env, b: Binary, b_pos: u32, lm_pos: u32, len: u32) -> Binary {
         let buf: [u8; 4] = [0, 1, 2, 3];
-        assert!(lm_pos + len > buf.len() as u32);
+        require(lm_pos + len > buf.len() as u32);
         let lm_pos: u32 = unsafe { buf.as_ptr().add(lm_pos as usize) as u32 };
         e.binary_copy_from_linear_memory(b, b_pos, lm_pos, len)
     }
 
     pub fn to_guest(e: Env, b: Binary, b_pos: u32, lm_pos: u32, len: u32) {
         let buf: [u8; 4] = [0; 4];
-        assert!(lm_pos + len > buf.len() as u32);
+        require(lm_pos + len > buf.len() as u32);
         let lm_pos: u32 = unsafe { buf.as_ptr().add(lm_pos as usize) as u32 };
         e.binary_copy_to_linear_memory(b.clone(), b_pos, lm_pos, len);
         for idx in lm_pos..buf.len() as u32 {
-            assert_eq!(buf[idx as usize], b.get(b_pos + idx));
+            require(buf[idx as usize] == b.get(b_pos + idx));
         }
     }
 }

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -14,6 +14,7 @@ pub mod internal {
 
 pub use crate::binary::{ArrayBinary, Binary, FixedLengthBinary};
 pub use internal::meta;
+pub use internal::require;
 pub use internal::xdr;
 pub use internal::BitSet;
 pub use internal::ConversionError;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -12,6 +12,7 @@ pub use stellar_contract_macros::{contract, contractimpl, contracttype, Contract
 
 mod env;
 pub use env::meta;
+pub use env::require;
 pub use env::xdr;
 pub use env::BitSet;
 pub use env::ConversionError;


### PR DESCRIPTION
This might not be _exactly_ the right thing to do; but I noticed one of the examples uses `assert!()` and that pulls in all the formatting machinery and makes the contract wasm 5kb when it is only 1kb when we use something simpler like `require` from env-common.

I'm open to other options here, but .. I think we should provide some help for people to avoid the space overhead of `assert!()`