### PR TITLE
Make contractimpl feature arg an attribute arg

### DIFF
--- a/examples/udt/Cargo.toml
+++ b/examples/udt/Cargo.toml
@@ -10,3 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}
+
+[features]
+default = ["export"]
+export = []

--- a/examples/udt/src/lib.rs
+++ b/examples/udt/src/lib.rs
@@ -17,7 +17,7 @@ pub struct UdtStruct {
 
 pub struct Contract;
 
-#[contractimpl]
+#[contractimpl(feature = "export")]
 impl Contract {
     pub fn add(a: UdtEnum, b: UdtEnum) -> i64 {
         let a = match a {

--- a/macros/src/args.rs
+++ b/macros/src/args.rs
@@ -1,0 +1,23 @@
+use quote::format_ident;
+use syn::{LitStr, NestedMeta};
+
+// TODO: Consider replacing this with crates.io/crates/darling.
+
+pub fn get_str(args: &Vec<NestedMeta>, name: &str) -> Option<LitStr> {
+    args.iter().find_map(|m| match m {
+        syn::NestedMeta::Meta(m) => match m {
+            syn::Meta::NameValue(nv) => {
+                if nv.path.is_ident(&format_ident!("{}", name)) {
+                    match &nv.lit {
+                        syn::Lit::Str(s) => Some(s.clone()),
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            }
+            syn::Meta::Path(_) | syn::Meta::List(_) => None,
+        },
+        syn::NestedMeta::Lit(_) => None,
+    })
+}

--- a/macros/src/args.rs
+++ b/macros/src/args.rs
@@ -1,23 +1,23 @@
 use quote::format_ident;
-use syn::{LitStr, NestedMeta};
+use syn::{Lit, LitStr, Meta, NestedMeta};
 
 // TODO: Consider replacing this with crates.io/crates/darling.
 
 pub fn get_str(args: &Vec<NestedMeta>, name: &str) -> Option<LitStr> {
     args.iter().find_map(|m| match m {
-        syn::NestedMeta::Meta(m) => match m {
-            syn::Meta::NameValue(nv) => {
+        NestedMeta::Meta(m) => match m {
+            Meta::NameValue(nv) => {
                 if nv.path.is_ident(&format_ident!("{}", name)) {
                     match &nv.lit {
-                        syn::Lit::Str(s) => Some(s.clone()),
+                        Lit::Str(s) => Some(s.clone()),
                         _ => None,
                     }
                 } else {
                     None
                 }
             }
-            syn::Meta::Path(_) | syn::Meta::List(_) => None,
+            Meta::Path(_) | Meta::List(_) => None,
         },
-        syn::NestedMeta::Lit(_) => None,
+        NestedMeta::Lit(_) => None,
     })
 }

--- a/macros/src/args.rs
+++ b/macros/src/args.rs
@@ -1,9 +1,9 @@
 use quote::format_ident;
-use syn::{Lit, LitStr, Meta, NestedMeta};
+use syn::{AttributeArgs, Lit, LitStr, Meta, NestedMeta};
 
 // TODO: Consider replacing this with crates.io/crates/darling.
 
-pub fn get_str(args: &Vec<NestedMeta>, name: &str) -> Option<LitStr> {
+pub fn get_str(args: &AttributeArgs, name: &str) -> Option<LitStr> {
     args.iter().find_map(|m| match m {
         NestedMeta::Meta(m) => match m {
             Meta::NameValue(nv) => {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -25,9 +25,9 @@ pub fn contract(_input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
-pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    let meta = parse_macro_input!(metadata as AttributeArgs);
-    let feature = args::get_str(&meta, "feature");
+pub fn contractimpl(args: TokenStream, input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(args as AttributeArgs);
+    let feature = args::get_str(&args, "feature");
     let imp = parse_macro_input!(input as ItemImpl);
     let is_trait = imp.trait_.is_some();
     let ty = &imp.self_ty;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate proc_macro;
 
+mod args;
 mod derive_fn;
 mod derive_type;
 mod map_type;
@@ -10,7 +11,8 @@ use derive_type::{derive_type_enum, derive_type_struct};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
-    parse_macro_input, spanned::Spanned, DeriveInput, Error, ImplItem, ItemImpl, LitStr, Visibility,
+    parse_macro_input, spanned::Spanned, AttributeArgs, DeriveInput, Error, ImplItem, ItemImpl,
+    Visibility,
 };
 
 #[proc_macro]
@@ -24,12 +26,8 @@ pub fn contract(_input: TokenStream) -> TokenStream {
 
 #[proc_macro_attribute]
 pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    let feature = if metadata.is_empty() {
-        None
-    } else {
-        Some(parse_macro_input!(metadata as LitStr))
-    };
-
+    let meta = parse_macro_input!(metadata as AttributeArgs);
+    let feature = args::get_str(&meta, "feature");
     let imp = parse_macro_input!(input as ItemImpl);
     let is_trait = imp.trait_.is_some();
     let ty = &imp.self_ty;


### PR DESCRIPTION
### What

Make contractimpl feature arg an attribute arg.

### Why

We plan to add additional arguments in https://github.com/stellar/rs-stellar-contract-sdk/issues/241, and having this be an argument with a name will make it easier to define the arguments without relying on their position in a list.

### Known limitations

We may prefer to use a crate like darling to simplify our parsing of tokens, and to generate better compile errors on things like typos or unsupported arguments. I didn't want to spend time on integrating that yet though, so I've added a TODO to revisit this.