### PR TITLE
Remove macOS, Windows builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,18 +37,19 @@ jobs:
           target: x86_64-unknown-linux-gnu
           profile: test
           test: true
-        - os: macos-latest
-          target: x86_64-apple-darwin
-          profile: test
-          test: true
-        - os: macos-latest
-          target: aarch64-apple-darwin
-          profile: test
-          test: false
-        - os: windows-latest
-          target: x86_64-pc-windows-msvc
-          profile: test
-          test: true
+        # TODO: Re-enable if we see value in doing so.
+        # - os: macos-latest
+        #   target: x86_64-apple-darwin
+        #   profile: test
+        #   test: true
+        # - os: macos-latest
+        #   target: aarch64-apple-darwin
+        #   profile: test
+        #   test: false
+        # - os: windows-latest
+        #   target: x86_64-pc-windows-msvc
+        #   profile: test
+        #   test: true
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### What

Remove macOS and Windows builds from CI.

### Why

The top level reason is build speed. Similar to https://github.com/stellar/rs-stellar-xdr/pull/119 and https://github.com/stellar/rs-stellar-contract-env/pull/237.

Regarding macOS: We have so many repos triggering macOS builds that I'm seeing them frequently blocking each other because of low macOS concurrency limits across our entire organization. There is only minimal value in running the tests across multiple environments. If we determine there is increased value, we can bring them back.

Regarding Windows: The windows builds are slow, both because runner availability is lower and so they take longer to queue and start, as well as compile times and test times being many times worse. Also, on the rs-stellar-xdr repo they are the main culprit of strange intermittent failures usually resulting from running out of disk space, or in one case strange or buggy rustup behavior. They're costing us more time than we are gaining in benefits.

### Known limitations

[TODO or N/A]
