### PR TITLE
Change contractimpl to generate module per function

### DIFF
--- a/examples/add_i32/src/lib.rs
+++ b/examples/add_i32/src/lib.rs
@@ -17,7 +17,7 @@ mod test {
     extern crate std;
     use std::panic::{catch_unwind, AssertUnwindSafe};
 
-    use super::__add::call as add;
+    use super::__add::call_raw as add;
     use stellar_contract_sdk::{Env, IntoVal, TryFromVal};
 
     #[test]
@@ -49,7 +49,7 @@ mod proptest {
     use proptest::prelude::*;
     use std::{format, panic};
 
-    use super::__add::call as add;
+    use super::__add::call_raw as add;
     use stellar_contract_sdk::{Env, IntoVal, TryFromVal};
 
     proptest! {

--- a/examples/add_i64/src/lib.rs
+++ b/examples/add_i64/src/lib.rs
@@ -9,7 +9,7 @@ contract!();
 
 pub struct Add1;
 
-#[contractimpl]
+#[contractimpl(tests_if = "testutils")]
 impl Add1 {
     fn addimpl(a: i64, b: i64) -> i64 {
         a + b
@@ -27,7 +27,7 @@ pub trait Add2Trait {
 
 pub struct Add2;
 
-#[contractimpl]
+#[contractimpl(tests_if = "testutils")]
 impl Add2Trait for Add2 {
     fn add2(_e: Env, a: i64, b: i64) -> i64 {
         a + b
@@ -59,7 +59,7 @@ mod test_via_val {
 
     #[test]
     fn test_add_val() {
-        for f in [__add1, __add2] {
+        for f in [__add1::call, __add2::call] {
             let e = Env::default();
             let x = 10i64.into_val(&e);
             let y = 12i64.into_val(&e);

--- a/examples/add_i64/src/lib.rs
+++ b/examples/add_i64/src/lib.rs
@@ -54,12 +54,12 @@ mod test {
 
 #[cfg(test)]
 mod test_via_val {
-    use super::{__add1, __add2};
+    use super::{__add1::call_raw as add1, __add2::call_raw as add2};
     use stellar_contract_sdk::{Env, IntoVal, TryFromVal};
 
     #[test]
     fn test_add_val() {
-        for f in [__add1::call, __add2::call] {
+        for f in [add1, add2] {
             let e = Env::default();
             let x = 10i64.into_val(&e);
             let y = 12i64.into_val(&e);

--- a/examples/contract_data/src/lib.rs
+++ b/examples/contract_data/src/lib.rs
@@ -5,7 +5,7 @@ contract!();
 
 pub struct Contract;
 
-#[contractimpl]
+#[contractimpl(tests_if = "testutils")]
 impl Contract {
     pub fn put(e: Env, key: Symbol, val: Symbol) {
         e.put_contract_data(key, val)

--- a/examples/create_contract/src/lib.rs
+++ b/examples/create_contract/src/lib.rs
@@ -5,7 +5,7 @@ contract!();
 
 pub struct Contract;
 
-#[contractimpl]
+#[contractimpl(tests_if = "testutils")]
 impl Contract {
     // Note that anyone can create a contract here with any salt, so a users call to
     // this could be frontrun and the same salt taken.

--- a/examples/linear_memory/src/lib.rs
+++ b/examples/linear_memory/src/lib.rs
@@ -5,7 +5,7 @@ contract!();
 
 pub struct Contract;
 
-#[contractimpl]
+#[contractimpl(tests_if = "testutils")]
 impl Contract {
     pub fn bin_new(e: Env, len: u32) -> Binary {
         let buf: [u8; 4] = [0, 1, 2, 3];

--- a/examples/udt/src/lib.rs
+++ b/examples/udt/src/lib.rs
@@ -41,7 +41,7 @@ mod test {
     fn test_add() {
         let e = Env::default();
         let udt = UdtStruct { a: 10, b: 12 };
-        let z = __add::call(
+        let z = __add::call_raw(
             e.clone(),
             UdtEnum::UdtA.into_val(&e),
             UdtEnum::UdtB(udt).into_val(&e),

--- a/examples/udt/src/lib.rs
+++ b/examples/udt/src/lib.rs
@@ -17,7 +17,7 @@ pub struct UdtStruct {
 
 pub struct Contract;
 
-#[contractimpl(feature = "export")]
+#[contractimpl(export_if = "export", tests_if = "testutils")]
 impl Contract {
     pub fn add(a: UdtEnum, b: UdtEnum) -> i64 {
         let a = match a {
@@ -41,7 +41,7 @@ mod test {
     fn test_add() {
         let e = Env::default();
         let udt = UdtStruct { a: 10, b: 12 };
-        let z = __add(
+        let z = __add::call(
             e.clone(),
             UdtEnum::UdtA.into_val(&e),
             UdtEnum::UdtB(udt).into_val(&e),

--- a/macros/src/derive_fn.rs
+++ b/macros/src/derive_fn.rs
@@ -166,3 +166,24 @@ pub fn derive_fn(
         }
     }
 }
+
+#[allow(clippy::too_many_lines)]
+pub fn derive_add_functions<'a>(
+    ty: &Box<Type>,
+    methods: impl Iterator<Item = &'a syn::ImplItemMethod>,
+) -> TokenStream2 {
+    let (idents, wrap_idents): (Vec<_>, Vec<_>) = methods
+        .map(|m| {
+            let ident = format!("{}", m.sig.ident);
+            let wrap_ident = format_ident!("__{}", m.sig.ident);
+            (ident, wrap_ident)
+        })
+        .multiunzip();
+    quote! {
+        impl stellar_contract_sdk::AddFunctions for #ty {
+            fn add_functions(tc: &mut stellar_contract_sdk::TestContract) {
+                #(tc.add_function(#idents, &#wrap_idents::call_slice));*
+            }
+        }
+    }
+}

--- a/macros/src/derive_fn.rs
+++ b/macros/src/derive_fn.rs
@@ -169,7 +169,7 @@ pub fn derive_fn(
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn derive_add_functions<'a>(
+pub fn derive_contract_function_set<'a>(
     ty: &Box<Type>,
     methods: impl Iterator<Item = &'a syn::ImplItemMethod>,
     feature: &Option<String>,

--- a/macros/src/derive_fn.rs
+++ b/macros/src/derive_fn.rs
@@ -147,7 +147,7 @@ pub fn derive_fn(
 
         pub mod #mod_ident {
             #export_name
-            pub fn call(env: stellar_contract_sdk::Env, #(#wrap_args),*) -> stellar_contract_sdk::RawVal {
+            pub fn call_raw(env: stellar_contract_sdk::Env, #(#wrap_args),*) -> stellar_contract_sdk::RawVal {
                 #use_trait;
                 <_ as stellar_contract_sdk::IntoVal<stellar_contract_sdk::Env, stellar_contract_sdk::RawVal>>::into_val(
                     #call(
@@ -158,11 +158,11 @@ pub fn derive_fn(
                 )
             }
 
-            pub fn call_slice(
+            pub fn call_raw_slice(
                 env: stellar_contract_sdk::Env,
                 args: &[stellar_contract_sdk::RawVal],
             ) -> stellar_contract_sdk::RawVal {
-                call(env, #(#slice_args),*)
+                call_raw(env, #(#slice_args),*)
             }
         }
     })
@@ -190,7 +190,7 @@ pub fn derive_add_functions<'a>(
         #cfg
         impl stellar_contract_sdk::AddFunctions for #ty {
             fn add_functions(tc: &mut stellar_contract_sdk::TestContract) {
-                #(tc.add_function(#idents, &#wrap_idents::call_slice));*
+                #(tc.add_function(#idents, &#wrap_idents::call_raw_slice));*
             }
         }
     }

--- a/macros/src/derive_fn.rs
+++ b/macros/src/derive_fn.rs
@@ -158,7 +158,10 @@ pub fn derive_fn(
                 )
             }
 
-            pub fn call_slice(env: stellar_contract_sdk::Env, args: &[stellar_contract_sdk::RawVal]) -> stellar_contract_sdk::RawVal {
+            pub fn call_slice(
+                env: stellar_contract_sdk::Env,
+                args: &[stellar_contract_sdk::RawVal],
+            ) -> stellar_contract_sdk::RawVal {
                 call(env, #(#slice_args),*)
             }
         }

--- a/macros/src/derive_fn.rs
+++ b/macros/src/derive_fn.rs
@@ -19,7 +19,7 @@ pub fn derive_fn(
     output: &ReturnType,
     feature: &Option<String>,
     trait_ident: &Option<&Ident>,
-) -> TokenStream2 {
+) -> Result<TokenStream2, TokenStream2> {
     // Collect errors as they are encountered and emit them at the end.
     let mut errors = Vec::<Error>::new();
 
@@ -101,7 +101,7 @@ pub fn derive_fn(
     // If errors have occurred, render them instead.
     if !errors.is_empty() {
         let compile_errors = errors.iter().map(Error::to_compile_error);
-        return quote! { #(#compile_errors)* };
+        return Err(quote! { #(#compile_errors)* });
     }
 
     // Generated code parameters.
@@ -141,7 +141,7 @@ pub fn derive_fn(
     };
 
     // Generated code.
-    quote! {
+    Ok(quote! {
         #link_section
         pub static #spec_ident: [u8; #spec_xdr_len] = *#spec_xdr_lit;
 
@@ -165,7 +165,7 @@ pub fn derive_fn(
                 call(env, #(#slice_args),*)
             }
         }
-    }
+    })
 }
 
 #[allow(clippy::too_many_lines)]

--- a/macros/src/derive_fn.rs
+++ b/macros/src/derive_fn.rs
@@ -188,9 +188,22 @@ pub fn derive_add_functions<'a>(
     };
     quote! {
         #cfg
-        impl stellar_contract_sdk::AddFunctions for #ty {
-            fn add_functions(tc: &mut stellar_contract_sdk::TestContract) {
-                #(tc.add_function(#idents, &#wrap_idents::call_raw_slice));*
+        impl stellar_contract_sdk::ContractFunctionSet for #ty {
+            fn call(
+                &self,
+                func: &stellar_contract_sdk::Symbol,
+                env: stellar_contract_sdk::Env,
+                args: &[stellar_contract_sdk::RawVal],
+            ) -> Option<stellar_contract_sdk::RawVal> {
+                use crate::std::string::ToString;
+                match func.to_string().as_str() {
+                    #(#idents => {
+                        Some(#wrap_idents::call_raw_slice(env, args))
+                    })*
+                    _ => {
+                        None
+                    }
+                }
             }
         }
     }

--- a/macros/src/derive_fn.rs
+++ b/macros/src/derive_fn.rs
@@ -195,8 +195,7 @@ pub fn derive_add_functions<'a>(
                 env: stellar_contract_sdk::Env,
                 args: &[stellar_contract_sdk::RawVal],
             ) -> Option<stellar_contract_sdk::RawVal> {
-                use crate::std::string::ToString;
-                match func.to_string().as_str() {
+                match func.to_str().as_ref() {
                     #(#idents => {
                         Some(#wrap_idents::call_raw_slice(env, args))
                     })*

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -50,8 +50,16 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
         .filter(|m| is_trait || matches!(m.vis, Visibility::Public(_)))
         .map(|m| {
             let ident = &m.sig.ident;
-            let call = quote! { <#ty>::#ident };
-            derive_fn(&call, ident, &m.sig.inputs, &m.sig.output, &args.feature)
+            let call = quote! { <super::#ty>::#ident };
+            let trait_ident = imp.trait_.as_ref().and_then(|x| x.1.get_ident());
+            derive_fn(
+                &call,
+                ident,
+                &m.sig.inputs,
+                &m.sig.output,
+                &args.feature,
+                &trait_ident,
+            )
         });
     quote! {
         #imp

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -75,13 +75,11 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
             }
             .into()
         }
-        Err(derived_err) => {
-            quote! {
-                #imp
-                #derived_err
-            }
-            .into()
+        Err(derived_err) => quote! {
+            #imp
+            #derived_err
         }
+        .into(),
     }
 }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -27,7 +27,8 @@ pub fn contract(_input: TokenStream) -> TokenStream {
 #[derive(Debug, FromMeta)]
 struct ContractImplArgs {
     #[darling(default)]
-    feature: Option<String>,
+    export_if: Option<String>,
+    tests_if: Option<String>,
 }
 
 fn get_methods(imp: &ItemImpl) -> impl Iterator<Item = &ImplItemMethod> {
@@ -58,11 +59,11 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
                 ident,
                 &m.sig.inputs,
                 &m.sig.output,
-                &args.feature,
+                &args.export_if,
                 &trait_ident,
             )
         });
-    let add_functions = derive_add_functions(ty, get_methods(&imp));
+    let add_functions = derive_add_functions(ty, get_methods(&imp), &args.tests_if);
     quote! {
         #imp
         #(#derived)*

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -4,7 +4,7 @@ mod derive_fn;
 mod derive_type;
 mod map_type;
 
-use derive_fn::{derive_add_functions, derive_fn};
+use derive_fn::{derive_contract_function_set, derive_fn};
 use derive_type::{derive_type_enum, derive_type_struct};
 
 use darling::FromMeta;
@@ -67,11 +67,11 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
 
     match derived {
         Ok(derived_ok) => {
-            let add_functions = derive_add_functions(ty, get_methods(&imp), &args.tests_if);
+            let cfs = derive_contract_function_set(ty, get_methods(&imp), &args.tests_if);
             quote! {
                 #imp
                 #derived_ok
-                #add_functions
+                #cfs
             }
             .into()
         }

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -205,7 +205,7 @@ impl Env {
 }
 
 #[cfg(feature = "testutils")]
-use crate::TestContract;
+use crate::test_contract::{ContractFunctionSet, InternalContractFunctionSet};
 #[cfg(feature = "testutils")]
 use std::rc::Rc;
 #[cfg(feature = "testutils")]
@@ -239,10 +239,14 @@ impl Env {
         }
     }
 
-    pub fn register_contract(&self, contract_id: RawVal, contract: TestContract) {
+    pub fn register_contract<T: ContractFunctionSet + 'static>(
+        &self,
+        contract_id: RawVal,
+        contract: T,
+    ) {
         let id_obj: Object = contract_id.try_into().unwrap();
         self.env_impl
-            .register_test_contract(id_obj, Rc::new(contract))
+            .register_test_contract(id_obj, Rc::new(InternalContractFunctionSet(contract)))
             .unwrap();
     }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -40,6 +40,6 @@ pub use vec::Vec;
 mod test_contract;
 mod test_sign;
 #[cfg(feature = "testutils")]
-pub use test_contract::TestContract;
+pub use test_contract::{AddFunctions, TestContract};
 #[cfg(feature = "testutils")]
 pub use test_sign::{ed25519, Sign};

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -40,6 +40,6 @@ pub use vec::Vec;
 mod test_contract;
 mod test_sign;
 #[cfg(feature = "testutils")]
-pub use test_contract::{AddFunctions, TestContract};
+pub use test_contract::ContractFunctionSet;
 #[cfg(feature = "testutils")]
 pub use test_sign::{ed25519, Sign};

--- a/sdk/src/test_contract.rs
+++ b/sdk/src/test_contract.rs
@@ -25,3 +25,7 @@ impl ContractFunctionSet for TestContract {
         Some(f(env, args))
     }
 }
+
+pub trait AddFunctions {
+    fn add_functions(tc: &mut TestContract);
+}

--- a/sdk/src/test_contract.rs
+++ b/sdk/src/test_contract.rs
@@ -1,31 +1,15 @@
 #![cfg(feature = "testutils")]
 
-use crate::env::{
-    internal::{ContractFunctionSet, EnvImpl},
-    Env, RawVal, Symbol,
-};
-use std::collections::HashMap;
+use crate::env::{internal, Env, RawVal, Symbol};
 
-pub struct TestContract(HashMap<Symbol, &'static dyn Fn(Env, &[RawVal]) -> RawVal>);
-
-impl TestContract {
-    pub fn new() -> TestContract {
-        TestContract(HashMap::new())
-    }
-
-    pub fn add_function(&mut self, name: &str, f: &'static dyn Fn(Env, &[RawVal]) -> RawVal) {
-        self.0.insert(Symbol::from_str(name), f);
-    }
+pub trait ContractFunctionSet {
+    fn call(&self, func: &Symbol, env: Env, args: &[RawVal]) -> Option<RawVal>;
 }
 
-impl ContractFunctionSet for TestContract {
-    fn call(&self, func: &Symbol, env_impl: &EnvImpl, args: &[RawVal]) -> Option<RawVal> {
-        let f = self.0.get(func)?;
-        let env = Env::with_impl(env_impl.clone());
-        Some(f(env, args))
-    }
-}
+pub(crate) struct InternalContractFunctionSet<T: ContractFunctionSet>(pub(crate) T);
 
-pub trait AddFunctions {
-    fn add_functions(tc: &mut TestContract);
+impl<T: ContractFunctionSet> internal::ContractFunctionSet for InternalContractFunctionSet<T> {
+    fn call(&self, func: &Symbol, env_impl: &internal::EnvImpl, args: &[RawVal]) -> Option<RawVal> {
+        self.0.call(func, Env::with_impl(env_impl.clone()), args)
+    }
 }

--- a/sdk/tests/macros_fails/macros_spec_i32.rs
+++ b/sdk/tests/macros_fails/macros_spec_i32.rs
@@ -4,7 +4,7 @@ pub struct MyType<A>(pub A);
 
 pub struct Contract;
 
-#[contractimpl]
+#[contractimpl(tests_if = "testutils")]
 impl Contract {
     pub fn add(a: MyType<i32>, b: MyType<i32>) -> i8 {
         unimplemented!()

--- a/sdk/tests/macros_spec_i32.rs
+++ b/sdk/tests/macros_spec_i32.rs
@@ -5,7 +5,7 @@ use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecFunctionV0, ScSpecTypeDef};
 
 pub struct Contract;
 
-#[contractimpl]
+#[contractimpl(tests_if = "testutils")]
 impl Contract {
     pub fn add(a: i32, b: i32) -> i32 {
         a + b
@@ -17,7 +17,7 @@ fn test_functional() {
     let e = Env::default();
     let a = 10i32.into_val(&e);
     let b = 12i32.into_val(&e);
-    let c = __add(e.clone(), a, b);
+    let c = __add::call(e.clone(), a, b);
     let c = i32::try_from_val(&e, c).unwrap();
     assert_eq!(c, 22);
 }

--- a/sdk/tests/macros_spec_i32.rs
+++ b/sdk/tests/macros_spec_i32.rs
@@ -17,7 +17,7 @@ fn test_functional() {
     let e = Env::default();
     let a = 10i32.into_val(&e);
     let b = 12i32.into_val(&e);
-    let c = __add::call(e.clone(), a, b);
+    let c = __add::call_raw(e.clone(), a, b);
     let c = i32::try_from_val(&e, c).unwrap();
     assert_eq!(c, 22);
 }

--- a/sdk/tests/macros_spec_udt.rs
+++ b/sdk/tests/macros_spec_udt.rs
@@ -30,7 +30,7 @@ impl IntoEnvVal<Env, RawVal> for Udt {
 
 pub struct Contract;
 
-#[contractimpl]
+#[contractimpl(tests_if = "testutils")]
 impl Contract {
     pub fn add(a: Udt, b: Udt) -> (Udt, Udt) {
         (a, b)
@@ -42,7 +42,7 @@ fn test_functional() {
     let e = Env::default();
     let a = Udt { a: 5, b: 7 };
     let b = Udt { a: 10, b: 14 };
-    let c = __add(e.clone(), a.into_val(&e), b.into_val(&e));
+    let c = __add::call(e.clone(), a.into_val(&e), b.into_val(&e));
     let c = <(Udt, Udt)>::try_from_val(&e, c).unwrap();
     assert_eq!(c, (a, b));
 }

--- a/sdk/tests/macros_spec_udt.rs
+++ b/sdk/tests/macros_spec_udt.rs
@@ -42,7 +42,7 @@ fn test_functional() {
     let e = Env::default();
     let a = Udt { a: 5, b: 7 };
     let b = Udt { a: 10, b: 14 };
-    let c = __add::call(e.clone(), a.into_val(&e), b.into_val(&e));
+    let c = __add::call_raw(e.clone(), a.into_val(&e), b.into_val(&e));
     let c = <(Udt, Udt)>::try_from_val(&e, c).unwrap();
     assert_eq!(c, (a, b));
 }


### PR DESCRIPTION
### What

Change `contractimpl` to generate a module per function, containing functions `call` and `call_slice`. Then generate function to register all the contract functions in a `TestContract`.

### Why

Makes the existence of wrapped functions generated by `contractimpl` invisible to developers.

### Known limitations

The design could use some improvement.