### PR TITLE
Fix leaked ref of type requiring use in macro

### DIFF
--- a/examples/udt/src/lib.rs
+++ b/examples/udt/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use stellar_contract_sdk::{contract, contractimpl, contracttype, ConversionError, IntoEnvVal};
+use stellar_contract_sdk::{contract, contractimpl, contracttype, IntoEnvVal};
 
 contract!();
 

--- a/macros/src/derive_type.rs
+++ b/macros/src/derive_type.rs
@@ -48,7 +48,7 @@ pub fn derive_type_struct(ident: &Ident, data: &DataStruct, spec: bool) -> Token
             let try_from = quote! {
                 #ident: map
                     .get(#map_key)
-                    .map_err(|_| ConversionError)?
+                    .map_err(|_| stellar_contract_sdk::ConversionError)?
                     .try_into()?
             };
             let into = quote! { map.insert(#map_key, self.#ident.into_env_val(env)) };


### PR DESCRIPTION
### What
Remove use from example and fully qualify the name of the type in the macro.

### Why
Macros shouldn't require use directives in their calling code.