### PR TITLE
Stop using RawVal in register_contract arguments

### DIFF
--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -241,10 +241,10 @@ impl Env {
 
     pub fn register_contract<T: ContractFunctionSet + 'static>(
         &self,
-        contract_id: RawVal,
+        contract_id: Binary,
         contract: T,
     ) {
-        let id_obj: Object = contract_id.try_into().unwrap();
+        let id_obj: Object = RawVal::from(contract_id).try_into().unwrap();
         self.env_impl
             .register_test_contract(id_obj, Rc::new(InternalContractFunctionSet(contract)))
             .unwrap();


### PR DESCRIPTION
### What

Use `Binary` instead of `RawVal`.

### Why

Cleaner interface.

### Known limitations

N/A