### PR TITLE
Fix macro BigInt in contract spec

### DIFF
--- a/macros/src/map_type.rs
+++ b/macros/src/map_type.rs
@@ -27,6 +27,7 @@ pub fn map_type(t: &Type) -> Result<ScSpecTypeDef, Error> {
                 "Bitset" => Ok(ScSpecTypeDef::Bitset),
                 "Status" => Ok(ScSpecTypeDef::Status),
                 "Binary" => Ok(ScSpecTypeDef::Binary),
+                "BigInt" => Ok(ScSpecTypeDef::BigInt),
                 s => Ok(ScSpecTypeDef::Udt(ScSpecTypeUdt {
                     name: s.try_into().map_err(|e| {
                         Error::new(


### PR DESCRIPTION
### What
Add mapping of BigInt type to the contract spec BigInt type.

### Why
So that BigInt's in user-defined types are mapped to the appropriate type in the contract spec.