### PR TITLE
Add helpers for asserting that test code panics

### DIFF
--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -254,6 +254,89 @@ impl Env {
     pub fn invoke_contract(&mut self, hf: xdr::HostFunction, args: xdr::ScVec) -> xdr::ScVal {
         self.env_impl.invoke_function(hf, args).unwrap()
     }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn clone_self_and_catch_panic<F, T>(&self, f: F) -> (Env, std::thread::Result<T>)
+    where
+        F: FnOnce(Env) -> T,
+    {
+        let hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| ()));
+        let deep_clone = self.deep_clone();
+        let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(deep_clone.clone())));
+        std::panic::set_hook(hook);
+        (deep_clone, res)
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    pub fn assert_panic_with_string<F, T: Debug>(&self, s: &str, f: F)
+    where
+        F: FnOnce(Env) -> T,
+    {
+        match self.clone_self_and_catch_panic(f) {
+            (_, Ok(v)) => panic!("inner function expected to panic, but returned {:?}", v),
+            (_, Err(e)) => match e.downcast_ref::<String>() {
+                None => match e.downcast_ref::<&str>() {
+                    Some(ps) => assert_eq!(*ps, s),
+                    None => panic!(
+                        "inner function panicked with unknown type when \"{}\" expected",
+                        s
+                    ),
+                },
+                Some(ps) => assert_eq!(*ps, s),
+            },
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    pub fn assert_panic_with_status<F, T: Debug>(&self, status: Status, f: F)
+    where
+        F: FnOnce(Env) -> T,
+    {
+        use stellar_contract_env_host::events::{DebugArg, HostEvent};
+
+        match self.clone_self_and_catch_panic(f) {
+            (_, Ok(v)) => panic!("inner function expected to panic, but returned {:?}", v),
+            (clone, Err(e)) => {
+                // Allow if there was a panic literally _carrying_ the status requested.
+                if let Some(st) = e.downcast_ref::<Status>() {
+                    assert_eq!(*st, status);
+                    return;
+                }
+                // Allow if the last debug log entry contains the status of requested.
+                if let Some(HostEvent::Debug(dbg)) = clone.env_impl.get_events().0.last() {
+                    for arg in dbg.args.iter() {
+                        if let DebugArg::Val(v) = arg {
+                            if let Ok(st) = TryInto::<Status>::try_into(*v) {
+                                if st == status {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Otherwise we're going to fail but we'll try to produce a useful diagnostic if
+                // the panic was a string, which many are.
+                if let Some(s) = e.downcast_ref::<String>() {
+                    panic!(
+                        "inner function panicked with \"{}\" when status {:?} expected",
+                        s, status
+                    );
+                }
+                if let Some(s) = e.downcast_ref::<&str>() {
+                    panic!(
+                        "inner function panicked with \"{}\" when status {:?} expected",
+                        s, status
+                    );
+                }
+                panic!(
+                    "inner function panicked with unknown type when status {:?} expected",
+                    status
+                );
+            }
+        }
+    }
 }
 
 impl internal::EnvBase for Env {

--- a/sdk/tests/assert_panic.rs
+++ b/sdk/tests/assert_panic.rs
@@ -1,0 +1,48 @@
+#![cfg(all(feature = "testutils", not(target_family = "wasm")))]
+
+use std::panic::panic_any;
+use stellar_contract_sdk::{Env, Status};
+use stellar_xdr::ScHostStorageErrorCode;
+
+#[test]
+fn test_assert_panic_with_status() {
+    let e = Env::with_empty_recording_storage();
+    let status: Status = ScHostStorageErrorCode::AccessToUnknownEntry.into();
+    e.assert_panic_with_status(status, |_env| panic_any(status));
+}
+
+#[test]
+fn test_assert_panic_with_string() {
+    let e = Env::with_empty_recording_storage();
+    e.assert_panic_with_string("oh no", |_env| panic!("oh no"));
+}
+
+#[test]
+fn test_assert_panic_with_fmt_string() {
+    let e = Env::with_empty_recording_storage();
+    e.assert_panic_with_string("oh no 123", |_env| panic!("oh no {}", 123));
+}
+
+#[test]
+#[should_panic]
+fn test_assert_panic_wrong_string() {
+    let e = Env::with_empty_recording_storage();
+    e.assert_panic_with_string("oh no", |_env| panic!("and yet"));
+}
+
+#[test]
+#[should_panic]
+fn test_assert_panic_with_wrong_status() {
+    let e = Env::with_empty_recording_storage();
+    let expected: Status = ScHostStorageErrorCode::AccessToUnknownEntry.into();
+    let got: Status = ScHostStorageErrorCode::GetOnDeletedKey.into();
+    e.assert_panic_with_status(expected, |_env| panic_any(got));
+}
+
+#[test]
+#[should_panic]
+fn test_assert_panic_with_wrong_type() {
+    let e = Env::with_empty_recording_storage();
+    let expected: Status = ScHostStorageErrorCode::AccessToUnknownEntry.into();
+    e.assert_panic_with_status(expected, |_env| panic_any(10));
+}


### PR DESCRIPTION
This adds some helpers to `Env` which help write tests that assert panics happen in narrow situations.

They are broadly wrappers around `catch_unwind` with a few caveats:

  - They capture some boilerplate for downcasting and inspecting the value carried in the panic
  - The status-seeking one actually tries to fish a matching status out of the debug log if the panic doesn't have it
  - They try to improve the odds of unwind-safety by deep-cloning the Env before getting under way
  - They remove and reinstall a panic hook so the test output isn't cluttered with spurious backtraces
 
Feel free to muck around with this, I just thought it might be useful for me to sketch.