### PR TITLE
Generate ContractFunctionSet containing only pub fns

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -70,7 +70,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
 
     match derived {
         Ok(derived_ok) => {
-            let cfs = derive_contract_function_set(ty, pub_methods.into_iter());
+            let cfs = derive_contract_function_set(ty, pub_methods.into_iter(), &args.tests_if);
             quote! {
                 #imp
                 #derived_ok

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -48,8 +48,11 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
     let imp = parse_macro_input!(input as ItemImpl);
     let is_trait = imp.trait_.is_some();
     let ty = &imp.self_ty;
-    let derived: Result<proc_macro2::TokenStream, proc_macro2::TokenStream> = get_methods(&imp)
+    let pub_methods: Vec<_> = get_methods(&imp)
         .filter(|m| is_trait || matches!(m.vis, Visibility::Public(_)))
+        .collect();
+    let derived: Result<proc_macro2::TokenStream, proc_macro2::TokenStream> = pub_methods
+        .iter()
         .map(|m| {
             let ident = &m.sig.ident;
             let call = quote! { <super::#ty>::#ident };
@@ -67,7 +70,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
 
     match derived {
         Ok(derived_ok) => {
-            let cfs = derive_contract_function_set(ty, get_methods(&imp), &args.tests_if);
+            let cfs = derive_contract_function_set(ty, pub_methods.into_iter());
             quote! {
                 #imp
                 #derived_ok


### PR DESCRIPTION
### What

Generate ContractFunctionSet containing only pub fns.

### Why

Implementations that do not impl traits may include private functions. Those private functions won't be intended to be called directly and so the other parts of the derive_fn macro won't generate a module function for them. We shouldn't put them into the contract function set either.

Close #285