### PR TITLE
Assume testutils is the common feature name for test only code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,7 @@ checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 name = "example_add_i32"
 version = "0.0.0"
 dependencies = [
+ "example_add_i32",
  "proptest",
  "stellar-contract-sdk",
 ]
@@ -243,6 +244,7 @@ dependencies = [
 name = "example_add_i64"
 version = "0.0.0"
 dependencies = [
+ "example_add_i64",
  "stellar-contract-sdk",
 ]
 
@@ -250,6 +252,7 @@ dependencies = [
 name = "example_contract_data"
 version = "0.0.0"
 dependencies = [
+ "example_contract_data",
  "stellar-contract-sdk",
 ]
 
@@ -257,6 +260,7 @@ dependencies = [
 name = "example_create_contract"
 version = "0.0.0"
 dependencies = [
+ "example_create_contract",
  "stellar-contract-sdk",
 ]
 
@@ -264,6 +268,7 @@ dependencies = [
 name = "example_linear_memory"
 version = "0.0.0"
 dependencies = [
+ "example_linear_memory",
  "stellar-contract-sdk",
 ]
 

--- a/macros/src/derive_fn.rs
+++ b/macros/src/derive_fn.rs
@@ -172,7 +172,6 @@ pub fn derive_fn(
 pub fn derive_contract_function_set<'a>(
     ty: &Box<Type>,
     methods: impl Iterator<Item = &'a syn::ImplItemMethod>,
-    feature: &Option<String>,
 ) -> TokenStream2 {
     let (idents, wrap_idents): (Vec<_>, Vec<_>) = methods
         .map(|m| {
@@ -181,13 +180,8 @@ pub fn derive_contract_function_set<'a>(
             (ident, wrap_ident)
         })
         .multiunzip();
-    let cfg = if let Some(cfg_feature) = feature {
-        quote! { #[cfg(feature = #cfg_feature)] }
-    } else {
-        quote! {}
-    };
     quote! {
-        #cfg
+        #[cfg(any(test, feature = "testutils"))]
         impl stellar_contract_sdk::ContractFunctionSet for #ty {
             fn call(
                 &self,

--- a/macros/src/derive_type.rs
+++ b/macros/src/derive_type.rs
@@ -194,7 +194,7 @@ pub fn derive_type_enum(ident: &Ident, data: &DataEnum, spec: bool) -> TokenStre
     let mut errors = Vec::<Error>::new();
 
     let variants = &data.variants;
-    let (spec_cases, discriminant_consts, try_froms, intos): (Vec<_>, Vec<_>, Vec<_>, Vec<_>) = variants
+    let (spec_cases, discriminant_consts, try_froms, intos, try_from_xdrs, into_xdrs): (Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>) = variants
         .iter()
         .map(|v| {
             // TODO: Choose discriminant type based on repr type of enum.
@@ -206,7 +206,7 @@ pub fn derive_type_enum(ident: &Ident, data: &DataEnum, spec: bool) -> TokenStre
             // TODO: Or, error on multi-field enum variants.
             // TODO: Handle field names longer than a symbol. Hash the name? Truncate the name?
             let ident = &v.ident;
-            let name = ident.to_string();
+            let name = &ident.to_string();
             let field = v.fields.iter().next();
             let discriminant_const_sym_ident = format_ident!("DISCRIMINANT_SYM_{}", name.to_uppercase());
             let discriminant_const_u64_ident = format_ident!("DISCRIMINANT_U64_{}", name.to_uppercase());
@@ -236,7 +236,18 @@ pub fn derive_type_enum(ident: &Ident, data: &DataEnum, spec: bool) -> TokenStre
                 };
                 let try_from = quote! { #discriminant_const_u64_ident => Self::#ident(value.try_into()?) };
                 let into = quote! { Self::#ident(value) => (#discriminant_const_sym_ident, value).into_env_val(env) };
-                (spec_case, discriminant_const, try_from, into)
+                let try_from_xdr = quote! {
+                    #name => Self::#ident(
+                        {
+                            let ev: stellar_contract_sdk::EnvVal = (&value).try_into_env_val(&ev.env).map_err(|_| stellar_contract_sdk::xdr::Error::Invalid)?;
+                            ev
+                        }
+                        .try_into()
+                        .map_err(|_| stellar_contract_sdk::xdr::Error::Invalid)?
+                    )
+                };
+                let into_xdr = quote! { Self::#ident(value) => (#name, value).try_into().map_err(|_| stellar_contract_sdk::xdr::Error::Invalid)? };
+                (spec_case, discriminant_const, try_from, into, try_from_xdr, into_xdr)
             } else {
                 let spec_case = ScSpecUdtUnionCaseV0 {
                     name: name.try_into().unwrap_or_else(|_| {
@@ -247,7 +258,9 @@ pub fn derive_type_enum(ident: &Ident, data: &DataEnum, spec: bool) -> TokenStre
                 };
                 let try_from = quote! { #discriminant_const_u64_ident => Self::#ident };
                 let into = quote! { Self::#ident => (#discriminant_const_sym_ident, ()).into_env_val(env) };
-                (spec_case, discriminant_const, try_from, into)
+                let try_from_xdr = quote! { #name => Self::#ident };
+                let into_xdr = quote! { Self::#ident => (#name, ()).try_into().map_err(|_| stellar_contract_sdk::xdr::Error::Invalid)? };
+                (spec_case, discriminant_const, try_from, into, try_from_xdr, into_xdr)
             }
         })
         .multiunzip();
@@ -300,6 +313,79 @@ pub fn derive_type_enum(ident: &Ident, data: &DataEnum, spec: bool) -> TokenStre
                 match self {
                     #(#intos,)*
                 }
+            }
+        }
+
+        #[cfg(any(test, feature = "testutils"))]
+        impl TryFrom<stellar_contract_sdk::EnvType<stellar_contract_sdk::xdr::ScVec>> for #ident {
+            type Error = stellar_contract_sdk::xdr::Error;
+            #[inline(always)]
+            fn try_from(ev: stellar_contract_sdk::EnvType<stellar_contract_sdk::xdr::ScVec>) -> Result<Self, Self::Error> {
+                use stellar_contract_sdk::xdr::Validate;
+                use stellar_contract_sdk::EnvType;
+                use stellar_contract_sdk::TryIntoEnvVal;
+                let (discriminant, value): (stellar_contract_sdk::xdr::ScSymbol, stellar_contract_sdk::xdr::ScVal) = ev.val.try_into().map_err(|_| stellar_contract_sdk::xdr::Error::Invalid)?;
+                let discriminant_name: &str = &discriminant.to_string()?;
+                Ok(match discriminant_name {
+                    #(#try_from_xdrs,)*
+                    _ => Err(stellar_contract_sdk::xdr::Error::Invalid)?,
+                })
+            }
+        }
+
+        #[cfg(any(test, feature = "testutils"))]
+        impl TryFrom<stellar_contract_sdk::EnvType<stellar_contract_sdk::xdr::ScObject>> for #ident {
+            type Error = stellar_contract_sdk::xdr::Error;
+            #[inline(always)]
+            fn try_from(ev: stellar_contract_sdk::EnvType<stellar_contract_sdk::xdr::ScObject>) -> Result<Self, Self::Error> {
+                if let stellar_contract_sdk::xdr::ScObject::Vec(vec) = ev.val {
+                    stellar_contract_sdk::EnvType{ env: ev.env, val: vec }.try_into()
+                } else {
+                    Err(stellar_contract_sdk::xdr::Error::Invalid)
+                }
+            }
+        }
+
+        #[cfg(any(test, feature = "testutils"))]
+        impl TryFrom<stellar_contract_sdk::EnvType<stellar_contract_sdk::xdr::ScVal>> for #ident {
+            type Error = stellar_contract_sdk::xdr::Error;
+            #[inline(always)]
+            fn try_from(ev: stellar_contract_sdk::EnvType<stellar_contract_sdk::xdr::ScVal>) -> Result<Self, Self::Error> {
+                if let stellar_contract_sdk::xdr::ScVal::Object(Some(obj)) = ev.val {
+                    stellar_contract_sdk::EnvType{ env: ev.env, val: obj }.try_into()
+                } else {
+                    Err(stellar_contract_sdk::xdr::Error::Invalid)
+                }
+            }
+        }
+
+        #[cfg(any(test, feature = "testutils"))]
+        impl TryInto<stellar_contract_sdk::xdr::ScVec> for #ident {
+            type Error = stellar_contract_sdk::xdr::Error;
+            #[inline(always)]
+            fn try_into(self) -> Result<stellar_contract_sdk::xdr::ScVec, Self::Error> {
+                extern crate alloc;
+                Ok(match self {
+                    #(#into_xdrs,)*
+                })
+            }
+        }
+
+        #[cfg(any(test, feature = "testutils"))]
+        impl TryInto<stellar_contract_sdk::xdr::ScObject> for #ident {
+            type Error = stellar_contract_sdk::xdr::Error;
+            #[inline(always)]
+            fn try_into(self) -> Result<stellar_contract_sdk::xdr::ScObject, Self::Error> {
+                Ok(stellar_contract_sdk::xdr::ScObject::Vec(self.try_into()?))
+            }
+        }
+
+        #[cfg(any(test, feature = "testutils"))]
+        impl TryInto<stellar_contract_sdk::xdr::ScVal> for #ident {
+            type Error = stellar_contract_sdk::xdr::Error;
+            #[inline(always)]
+            fn try_into(self) -> Result<stellar_contract_sdk::xdr::ScVal, Self::Error> {
+                Ok(stellar_contract_sdk::xdr::ScVal::Object(Some(self.try_into()?)))
             }
         }
     }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -28,7 +28,6 @@ pub fn contract(_input: TokenStream) -> TokenStream {
 struct ContractImplArgs {
     #[darling(default)]
     export_if: Option<String>,
-    tests_if: Option<String>,
 }
 
 fn get_methods(imp: &ItemImpl) -> impl Iterator<Item = &ImplItemMethod> {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -48,8 +48,11 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
     let imp = parse_macro_input!(input as ItemImpl);
     let is_trait = imp.trait_.is_some();
     let ty = &imp.self_ty;
-    let derived: Result<proc_macro2::TokenStream, proc_macro2::TokenStream> = get_methods(&imp)
+    let pub_methods: Vec<_> = get_methods(&imp)
         .filter(|m| is_trait || matches!(m.vis, Visibility::Public(_)))
+        .collect();
+    let derived: Result<proc_macro2::TokenStream, proc_macro2::TokenStream> = pub_methods
+        .iter()
         .map(|m| {
             let ident = &m.sig.ident;
             let call = quote! { <super::#ty>::#ident };
@@ -67,7 +70,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
 
     match derived {
         Ok(derived_ok) => {
-            let cfs = derive_contract_function_set(ty, get_methods(&imp), &args.tests_if);
+            let cfs = derive_contract_function_set(ty, pub_methods.into_iter());
             quote! {
                 #imp
                 #derived_ok

--- a/sdk/tests/macros_fails/macros_spec_i32.rs
+++ b/sdk/tests/macros_fails/macros_spec_i32.rs
@@ -4,7 +4,7 @@ pub struct MyType<A>(pub A);
 
 pub struct Contract;
 
-#[contractimpl(tests_if = "testutils")]
+#[contractimpl]
 impl Contract {
     pub fn add(a: MyType<i32>, b: MyType<i32>) -> i8 {
         unimplemented!()

--- a/sdk/tests/macros_spec_i32.rs
+++ b/sdk/tests/macros_spec_i32.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "testutils")]
+
 use std::io::Cursor;
 
 use stellar_contract_sdk::{contractimpl, Env, IntoVal, TryFromVal};
@@ -5,7 +7,7 @@ use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecFunctionV0, ScSpecTypeDef};
 
 pub struct Contract;
 
-#[contractimpl(tests_if = "testutils")]
+#[contractimpl]
 impl Contract {
     pub fn add(a: i32, b: i32) -> i32 {
         a + b

--- a/sdk/tests/macros_spec_udt.rs
+++ b/sdk/tests/macros_spec_udt.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "testutils")]
+
 use std::io::Cursor;
 
 use stellar_contract_sdk::{
@@ -30,7 +32,7 @@ impl IntoEnvVal<Env, RawVal> for Udt {
 
 pub struct Contract;
 
-#[contractimpl(tests_if = "testutils")]
+#[contractimpl]
 impl Contract {
     pub fn add(a: Udt, b: Udt) -> (Udt, Udt) {
         (a, b)

--- a/tests/add_i32/Cargo.toml
+++ b/tests/add_i32/Cargo.toml
@@ -13,3 +13,8 @@ stellar-contract-sdk = {path = "../../sdk"}
 
 [dev-dependencies]
 proptest = "1.0.0"
+stellar-contract-sdk = {path = "../../sdk", features = ["testutils"]}
+example_add_i32 = {path = ".", features = ["testutils"]}
+
+[features]
+testutils = ["stellar-contract-sdk/testutils"]

--- a/tests/add_i32/src/lib.rs
+++ b/tests/add_i32/src/lib.rs
@@ -5,7 +5,7 @@ contract!();
 
 pub struct Contract;
 
-#[contractimpl(tests_if = "testutils")]
+#[contractimpl]
 impl Contract {
     pub fn add(a: i32, b: i32) -> i32 {
         a + b

--- a/tests/add_i64/Cargo.toml
+++ b/tests/add_i64/Cargo.toml
@@ -10,3 +10,10 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}
+
+[dev-dependencies]
+stellar-contract-sdk = {path = "../../sdk", features = ["testutils"]}
+example_add_i64 = {path = ".", features = ["testutils"]}
+
+[features]
+testutils = ["stellar-contract-sdk/testutils"]

--- a/tests/add_i64/src/lib.rs
+++ b/tests/add_i64/src/lib.rs
@@ -9,7 +9,7 @@ contract!();
 
 pub struct Add1;
 
-#[contractimpl(tests_if = "testutils")]
+#[contractimpl]
 impl Add1 {
     fn addimpl(a: i64, b: i64) -> i64 {
         a + b
@@ -27,7 +27,7 @@ pub trait Add2Trait {
 
 pub struct Add2;
 
-#[contractimpl(tests_if = "testutils")]
+#[contractimpl]
 impl Add2Trait for Add2 {
     fn add2(_e: Env, a: i64, b: i64) -> i64 {
         a + b

--- a/tests/contract_data/Cargo.toml
+++ b/tests/contract_data/Cargo.toml
@@ -10,3 +10,10 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}
+
+[dev-dependencies]
+stellar-contract-sdk = {path = "../../sdk", features = ["testutils"]}
+example_contract_data = {path = ".", features = ["testutils"]}
+
+[features]
+testutils = ["stellar-contract-sdk/testutils"]

--- a/tests/contract_data/src/lib.rs
+++ b/tests/contract_data/src/lib.rs
@@ -5,7 +5,7 @@ contract!();
 
 pub struct Contract;
 
-#[contractimpl(tests_if = "testutils")]
+#[contractimpl]
 impl Contract {
     pub fn put(e: Env, key: Symbol, val: Symbol) {
         e.put_contract_data(key, val)

--- a/tests/create_contract/Cargo.toml
+++ b/tests/create_contract/Cargo.toml
@@ -10,3 +10,10 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}
+
+[dev-dependencies]
+stellar-contract-sdk = {path = "../../sdk", features = ["testutils"]}
+example_create_contract = {path = ".", features = ["testutils"]}
+
+[features]
+testutils = ["stellar-contract-sdk/testutils"]

--- a/tests/create_contract/src/lib.rs
+++ b/tests/create_contract/src/lib.rs
@@ -5,7 +5,7 @@ contract!();
 
 pub struct Contract;
 
-#[contractimpl(tests_if = "testutils")]
+#[contractimpl]
 impl Contract {
     // Note that anyone can create a contract here with any salt, so a users call to
     // this could be frontrun and the same salt taken.

--- a/tests/linear_memory/Cargo.toml
+++ b/tests/linear_memory/Cargo.toml
@@ -10,3 +10,10 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 stellar-contract-sdk = {path = "../../sdk"}
+
+[dev-dependencies]
+stellar-contract-sdk = {path = "../../sdk", features = ["testutils"]}
+example_linear_memory = {path = ".", features = ["testutils"]}
+
+[features]
+testutils = ["stellar-contract-sdk/testutils"]

--- a/tests/linear_memory/src/lib.rs
+++ b/tests/linear_memory/src/lib.rs
@@ -5,7 +5,7 @@ contract!();
 
 pub struct Contract;
 
-#[contractimpl(tests_if = "testutils")]
+#[contractimpl]
 impl Contract {
     pub fn bin_new(e: Env, len: u32) -> Binary {
         let buf: [u8; 4] = [0, 1, 2, 3];

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -20,7 +20,7 @@ pub struct UdtStruct {
 
 pub struct Contract;
 
-#[contractimpl(export_if = "export", tests_if = "testutils")]
+#[contractimpl(export_if = "export")]
 impl Contract {
     pub fn add(a: UdtEnum, b: UdtEnum) -> i64 {
         let a = match a {


### PR DESCRIPTION
### What
Make the macros all generate code intended for testing gated behind the feature `testutils` rather than making it configurable via `tests_if`.

### Why
@jonjove mentioned that the `testutils` pattern is pretty common in Rust. We will need a `tests_if` attribute on every `contracttype` and `contractimpl` if we make keep it configurable. That is pretty noisy in the code. We have macros that hardcode the value and some that don't, and making them configurable with the simpler of the two options is an okay short term solution until we figure out what we should do.

### Known Issues
What we have now doesn't present the best developer experience, but also this doesn't present the best developer experience either. This likely needs revisiting.

cc @jonjove @sisuresh 