### PR TITLE
Move meta custom section into sdk

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -15,15 +15,6 @@ use syn::{
     ImplItemMethod, ItemImpl, Visibility,
 };
 
-#[proc_macro]
-pub fn contract(_input: TokenStream) -> TokenStream {
-    quote! {
-        #[cfg_attr(target_family = "wasm", link_section = "contractenvmetav0")]
-        pub static __ENV_META_XDR: [u8; stellar_contract_sdk::meta::XDR.len()] = stellar_contract_sdk::meta::XDR;
-    }
-    .into()
-}
-
 #[derive(Debug, FromMeta)]
 struct ContractImplArgs {
     #[darling(default)]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -8,10 +8,12 @@
 #[cfg(target_family = "wasm")]
 use stellar_contract_env_panic_handler_wasm32_unreachable as _;
 
-pub use stellar_contract_macros::{contract, contractimpl, contracttype, ContractType};
+#[cfg_attr(target_family = "wasm", link_section = "contractenvmetav0")]
+static ENV_META_XDR: [u8; env::meta::XDR.len()] = env::meta::XDR;
+
+pub use stellar_contract_macros::{contractimpl, contracttype, ContractType};
 
 mod env;
-pub use env::meta;
 pub use env::xdr;
 pub use env::BitSet;
 pub use env::ConversionError;

--- a/tests/add_i32/src/lib.rs
+++ b/tests/add_i32/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
-use stellar_contract_sdk::{contract, contractimpl};
-
-contract!();
+use stellar_contract_sdk::contractimpl;
 
 pub struct Contract;
 

--- a/tests/add_i64/src/lib.rs
+++ b/tests/add_i64/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
-use stellar_contract_sdk::{contract, contractimpl, Env};
-
-contract!();
+use stellar_contract_sdk::{contractimpl, Env};
 
 // There are two ways to export contract fns:
 

--- a/tests/contract_data/src/lib.rs
+++ b/tests/contract_data/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
-use stellar_contract_sdk::{contract, contractimpl, Env, Symbol};
-
-contract!();
+use stellar_contract_sdk::{contractimpl, Env, Symbol};
 
 pub struct Contract;
 

--- a/tests/create_contract/src/lib.rs
+++ b/tests/create_contract/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
-use stellar_contract_sdk::{contract, contractimpl, Binary, Env};
-
-contract!();
+use stellar_contract_sdk::{contractimpl, Binary, Env};
 
 pub struct Contract;
 

--- a/tests/linear_memory/src/lib.rs
+++ b/tests/linear_memory/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
-use stellar_contract_sdk::{contract, contractimpl, Binary, Env, FixedLengthBinary};
-
-contract!();
+use stellar_contract_sdk::{contractimpl, Binary, Env, FixedLengthBinary};
 
 pub struct Contract;
 

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
-use stellar_contract_sdk::{contract, contractimpl, contracttype, IntoEnvVal, Vec};
-
-contract!();
+use stellar_contract_sdk::{contractimpl, contracttype, IntoEnvVal, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
### What
Move the meta custom section out of a macro that runs in the contract and into the sdk.

### Why
There's no need for the meta section to be specified in the contract. It can be specified in the SDK and it will be built into the contract. This reduces the need for a random `contract!()` macro to appear in every contract, which is nice.

For #173 