### PR TITLE
Fix vec macro when trailing comma

### DIFF
--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -50,9 +50,15 @@ impl<C> IntoTryFromVal for C where C: IntoVal<Env, RawVal> + TryFromVal<Env, Raw
 
 use crate::binary::{ArrayBinary, Binary};
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct Env {
     env_impl: internal::EnvImpl,
+}
+
+impl Default for Env {
+    fn default() -> Self {
+        Self { env_impl: Default::default() }
+    }
 }
 
 impl Env {

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -50,15 +50,9 @@ impl<C> IntoTryFromVal for C where C: IntoVal<Env, RawVal> + TryFromVal<Env, Raw
 
 use crate::binary::{ArrayBinary, Binary};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Env {
     env_impl: internal::EnvImpl,
-}
-
-impl Default for Env {
-    fn default() -> Self {
-        Self { env_impl: Default::default() }
-    }
 }
 
 impl Env {

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -487,7 +487,7 @@ mod test {
     #[test]
     fn test_vec_macro() {
         let env = Env::default();
-        assert_eq!(vec![&env], Vec::new(&env));
+        assert_eq!(vec![&env], Vec::<i32>::new(&env));
         assert_eq!(vec![&env, 1], {
             let mut v = Vec::new(&env);
             v.push(1);

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -487,6 +487,7 @@ mod test {
     #[test]
     fn test_vec_macro() {
         let env = Env::default();
+        assert_eq!(vec![&env], Vec::new(&env));
         assert_eq!(vec![&env, 1], {
             let mut v = Vec::new(&env);
             v.push(1);

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -21,6 +21,9 @@ macro_rules! vec {
     ($env:expr, $($x:expr),+) => {
         $crate::Vec::from_array($env, [$($x),+])
     };
+    ($env:expr, $($x:expr),+,) => {
+        $crate::Vec::from_array($env, [$($x),+])
+    };
 }
 
 #[derive(Clone)]
@@ -480,6 +483,28 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_vec_macro() {
+        let env = Env::default();
+        assert_eq!(vec![&env, 1], {
+            let mut v = Vec::new(&env);
+            v.push(1);
+            v
+        });
+        assert_eq!(vec![&env, 1,], {
+            let mut v = Vec::new(&env);
+            v.push(1);
+            v
+        });
+        assert_eq!(vec![&env, 3, 2, 1,], {
+            let mut v = Vec::new(&env);
+            v.push(3);
+            v.push(2);
+            v.push(1);
+            v
+        });
+    }
 
     #[test]
     fn test_vec_raw_val_type() {


### PR DESCRIPTION
### What
Add a new match rule to the vec! macro that allows for a trailing comma.

### Why
When rustfmt formats long vec lists it will add a trailing comma to the end of the last item, which was not supported by the macro.