### PR TITLE
Fix map macro when trailing comma

### DIFF
--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -12,7 +12,7 @@ macro_rules! map {
     ($env:expr) => {
         $crate::Map::new($env)
     };
-    ($env:expr, $(($k:expr, $v:expr)),+ $(,)?) => {
+    ($env:expr, $(($k:expr, $v:expr $(,)?)),+ $(,)?) => {
         $crate::Map::from_array($env, [$(($k, $v)),+])
     };
 }
@@ -416,6 +416,13 @@ mod test {
             v
         });
         assert_eq!(map![&env, (3, 30), (2, 20), (1, 10),], {
+            let mut v = Map::new(&env);
+            v.insert(3, 30);
+            v.insert(2, 20);
+            v.insert(1, 10);
+            v
+        });
+        assert_eq!(map![&env, (3, 30,), (2, 20,), (1, 10,),], {
             let mut v = Map::new(&env);
             v.insert(3, 30);
             v.insert(2, 20);

--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -12,7 +12,7 @@ macro_rules! map {
     ($env:expr) => {
         $crate::Map::new($env)
     };
-    ($env:expr, $(($k:expr, $v:expr)),+) => {
+    ($env:expr, $(($k:expr, $v:expr)),+ $(,)?) => {
         $crate::Map::from_array($env, [$(($k, $v)),+])
     };
 }
@@ -400,6 +400,29 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_map_macro() {
+        let env = Env::default();
+        assert_eq!(map![&env], Map::<i32, i32>::new(&env));
+        assert_eq!(map![&env, (1, 10)], {
+            let mut v = Map::new(&env);
+            v.insert(1, 10);
+            v
+        });
+        assert_eq!(map![&env, (1, 10),], {
+            let mut v = Map::new(&env);
+            v.insert(1, 10);
+            v
+        });
+        assert_eq!(map![&env, (3, 30), (2, 20), (1, 10),], {
+            let mut v = Map::new(&env);
+            v.insert(3, 30);
+            v.insert(2, 20);
+            v.insert(1, 10);
+            v
+        });
+    }
 
     #[test]
     fn test_empty() {


### PR DESCRIPTION
### What
Update match rule of the map! macro to allow for a trailing comma.

### Why
When rustfmt formats long map lists it will add a trailing comma to the end of the last item, which was not supported by the macro.

For https://github.com/stellar/rs-stellar-contract-sdk/issues/282