### PR TITLE
Rename Vec,Binary put => set

### DIFF
--- a/macros/src/derive_type.rs
+++ b/macros/src/derive_type.rs
@@ -48,7 +48,7 @@ pub fn derive_type_struct(ident: &Ident, data: &DataStruct, spec: bool) -> Token
             let try_from = quote! {
                 #ident: map.get(#map_key).map_err(|_| stellar_contract_sdk::ConversionError)?.try_into()?
             };
-            let into = quote! { map.insert(#map_key, self.#ident.into_env_val(env)) };
+            let into = quote! { map.set(#map_key, self.#ident.into_env_val(env)) };
             let try_from_xdr = quote! {
                 #ident: {
                     let key = &#name.try_into().map_err(|_| stellar_contract_sdk::xdr::Error::Invalid)?;

--- a/sdk/src/binary.rs
+++ b/sdk/src/binary.rs
@@ -160,7 +160,7 @@ impl Binary {
     }
 
     #[inline(always)]
-    pub fn put(&mut self, i: u32, v: u8) {
+    pub fn set(&mut self, i: u32, v: u8) {
         let v32: u32 = v.into();
         self.0 = self
             .env()
@@ -558,8 +558,8 @@ impl<const N: u32> ArrayBinary<N> {
     }
 
     #[inline(always)]
-    pub fn put(&mut self, i: u32, v: u8) {
-        self.0.put(i, v);
+    pub fn set(&mut self, i: u32, v: u8) {
+        self.0.set(i, v);
     }
 
     #[inline(always)]

--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -173,7 +173,7 @@ impl<K: IntoTryFromVal, V: IntoTryFromVal> Map<K, V> {
     pub fn from_array<const N: usize>(env: &Env, items: [(K, V); N]) -> Map<K, V> {
         let mut map = Map::<K, V>::new(env);
         for (k, v) in items {
-            map.insert(k, v);
+            map.set(k, v);
         }
         map
     }
@@ -209,7 +209,7 @@ impl<K: IntoTryFromVal, V: IntoTryFromVal> Map<K, V> {
     }
 
     #[inline(always)]
-    pub fn insert(&mut self, k: K, v: V) {
+    pub fn set(&mut self, k: K, v: V) {
         let env = self.env();
         let map = env.map_put(self.0.to_tagged(), k.into_val(env), v.into_val(env));
         self.0 = map.in_env(env);
@@ -407,26 +407,26 @@ mod test {
         assert_eq!(map![&env], Map::<i32, i32>::new(&env));
         assert_eq!(map![&env, (1, 10)], {
             let mut v = Map::new(&env);
-            v.insert(1, 10);
+            v.set(1, 10);
             v
         });
         assert_eq!(map![&env, (1, 10),], {
             let mut v = Map::new(&env);
-            v.insert(1, 10);
+            v.set(1, 10);
             v
         });
         assert_eq!(map![&env, (3, 30), (2, 20), (1, 10),], {
             let mut v = Map::new(&env);
-            v.insert(3, 30);
-            v.insert(2, 20);
-            v.insert(1, 10);
+            v.set(3, 30);
+            v.set(2, 20);
+            v.set(1, 10);
             v
         });
         assert_eq!(map![&env, (3, 30,), (2, 20,), (1, 10,),], {
             let mut v = Map::new(&env);
-            v.insert(3, 30);
-            v.insert(2, 20);
-            v.insert(1, 10);
+            v.set(3, 30);
+            v.set(2, 20);
+            v.set(1, 10);
             v
         });
     }

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -265,7 +265,7 @@ impl<T: IntoTryFromVal> Vec<T> {
     }
 
     #[inline(always)]
-    pub fn pop_back(&mut self) -> Result<T, VecAccessError<T>> {
+    pub fn pop(&mut self) -> Result<T, VecAccessError<T>> {
         let last = self.last()?;
         let env = self.env();
         let vec = env.vec_pop(self.0.to_tagged());
@@ -274,7 +274,7 @@ impl<T: IntoTryFromVal> Vec<T> {
     }
 
     #[inline(always)]
-    pub fn pop_back_unchecked(&mut self) -> T
+    pub fn pop_unchecked(&mut self) -> T
     where
         T::Error: Debug,
     {
@@ -529,7 +529,7 @@ mod test {
         assert_eq!(vec.len(), 3);
         assert_eq!(vec_ref.len(), 3);
 
-        _ = vec_copy.pop_back_unchecked();
+        _ = vec_copy.pop_unchecked();
         assert!(vec == vec_copy);
     }
 
@@ -559,7 +559,7 @@ mod test {
         assert_eq!(vec.len(), 3);
         assert_eq!(vec_ref.len(), 3);
 
-        _ = vec_copy.pop_back_unchecked();
+        _ = vec_copy.pop_unchecked();
         assert!(vec == vec_copy);
     }
 

--- a/sdk/src/vec.rs
+++ b/sdk/src/vec.rs
@@ -220,7 +220,7 @@ impl<T: IntoTryFromVal> Vec<T> {
     }
 
     #[inline(always)]
-    pub fn put(&mut self, i: u32, v: T) {
+    pub fn set(&mut self, i: u32, v: T) {
         let env = self.env();
         let vec = env.vec_put(self.0.to_tagged(), i.into(), v.into_val(env));
         self.0 = vec.in_env(env);


### PR DESCRIPTION
### What
Rename Vec,Binary put => set

### Why
Minor ergonomic improvement, maybe. There's not really a standard thing to call this function that has the subtle behavior of inserting with a replacement, since most languages use the `[` `]` syntax which we can't use here. Taking a page out of Java's Vector and using `set`.