### PR TITLE
Move Binary serialize/deserialize into traits

### DIFF
--- a/sdk/src/binary.rs
+++ b/sdk/src/binary.rs
@@ -8,7 +8,7 @@ use core::{
 
 use super::{
     env::internal::Env as _, env::EnvType, xdr::ScObjectType, ConversionError, Env, EnvObj, EnvVal,
-    RawVal, RawValConvertible,
+    Object, RawVal, RawValConvertible,
 };
 
 #[cfg(not(target_family = "wasm"))]
@@ -100,6 +100,20 @@ impl From<Binary> for EnvObj {
     }
 }
 
+impl From<Binary> for Object {
+    #[inline(always)]
+    fn from(v: Binary) -> Self {
+        v.0.val
+    }
+}
+
+impl From<&Binary> for Object {
+    #[inline(always)]
+    fn from(v: &Binary) -> Self {
+        v.0.val
+    }
+}
+
 #[cfg(not(target_family = "wasm"))]
 impl TryFrom<&Binary> for ScVal {
     type Error = ConversionError;
@@ -130,7 +144,7 @@ impl TryFrom<EnvType<ScVal>> for Binary {
 
 impl Binary {
     #[inline(always)]
-    unsafe fn unchecked_new(obj: EnvObj) -> Self {
+    pub(crate) unsafe fn unchecked_new(obj: EnvObj) -> Self {
         Self(obj)
     }
 

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -111,21 +111,6 @@ impl Env {
         internal::Env::del_contract_data(self, key.into_val(self));
     }
 
-    pub fn serialize_to_binary<V: IntoTryFromVal>(&self, val: V) -> Binary {
-        let val_obj: Object = val.into_val(self).try_into().unwrap();
-        let bin_obj = internal::Env::serialize_to_binary(self, val_obj.to_raw());
-        bin_obj.in_env(self).try_into().unwrap()
-    }
-
-    pub fn deserialize_from_binary<V: IntoTryFromVal>(&self, bin: Binary) -> V
-    where
-        V::Error: Debug,
-    {
-        let bin_obj: Object = RawVal::from(bin).try_into().unwrap();
-        let val_obj = internal::Env::deserialize_from_binary(self, bin_obj);
-        V::try_from_val(self, val_obj).unwrap()
-    }
-
     pub fn compute_hash_sha256(&self, msg: Binary) -> Binary {
         let bin_obj = internal::Env::compute_hash_sha256(self, msg.into_val(self));
         bin_obj.in_env(self).try_into().unwrap()

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -48,4 +48,6 @@ pub use binary::{ArrayBinary, Binary};
 pub use map::Map;
 pub use vec::Vec;
 
+pub mod serde;
+
 pub mod testutils;

--- a/sdk/src/serde.rs
+++ b/sdk/src/serde.rs
@@ -1,0 +1,33 @@
+use crate::{internal::Env as _, Binary, Env, IntoVal, RawVal, TryFromVal};
+
+pub trait Serialize {
+    fn serialize(&self, env: &Env) -> Binary;
+}
+
+pub trait Deserialize: Sized {
+    type Error;
+    fn deserialize(env: &Env, b: &Binary) -> Result<Self, Self::Error>;
+}
+
+impl<T> Serialize for T
+where
+    for<'a> &'a T: IntoVal<Env, RawVal>,
+{
+    fn serialize(&self, env: &Env) -> Binary {
+        let val: RawVal = self.into_val(env);
+        let bin = env.serialize_to_binary(val);
+        unsafe { Binary::unchecked_new(bin.in_env(env)) }
+    }
+}
+
+impl<T> Deserialize for T
+where
+    T: TryFromVal<Env, RawVal>,
+{
+    type Error = T::Error;
+
+    fn deserialize(env: &Env, b: &Binary) -> Result<Self, Self::Error> {
+        let t = env.deserialize_from_binary(b.into());
+        T::try_from_val(env, t)
+    }
+}

--- a/sdk/src/serde.rs
+++ b/sdk/src/serde.rs
@@ -1,7 +1,7 @@
 use crate::{internal::Env as _, Binary, Env, IntoVal, RawVal, TryFromVal};
 
 pub trait Serialize {
-    fn serialize(&self, env: &Env) -> Binary;
+    fn serialize(self, env: &Env) -> Binary;
 }
 
 pub trait Deserialize: Sized {
@@ -11,9 +11,9 @@ pub trait Deserialize: Sized {
 
 impl<T> Serialize for T
 where
-    for<'a> &'a T: IntoVal<Env, RawVal>,
+    T: IntoVal<Env, RawVal>,
 {
-    fn serialize(&self, env: &Env) -> Binary {
+    fn serialize(self, env: &Env) -> Binary {
         let val: RawVal = self.into_val(env);
         let bin = env.serialize_to_binary(val);
         unsafe { Binary::unchecked_new(bin.in_env(env)) }

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -36,7 +36,127 @@ impl Contract {
 #[cfg(test)]
 mod test {
     use super::{UdtEnum, UdtStruct, __add};
-    use stellar_contract_sdk::{vec, xdr::ScVal, Env, IntoVal, TryFromVal};
+    use stellar_contract_sdk::{vec, xdr::ScVal, Binary, Env, IntoVal, TryFromVal};
+
+    #[test]
+    fn test_serializing() {
+        use stellar_contract_sdk::serde::Serialize;
+        let e = Env::default();
+        let udt = UdtStruct {
+            a: 10,
+            b: 12,
+            c: vec![&e, 1],
+        };
+        let bin = udt.serialize(&e);
+        assert_eq!(bin, {
+            let mut bin = Binary::new(&e);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(4);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(1);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(1);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(3);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(5);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(1);
+            bin.push(97);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(10);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(5);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(1);
+            bin.push(98);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(12);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(5);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(1);
+            bin.push(99);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(4);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(1);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(1);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(0);
+            bin.push(1);
+            bin
+        })
+    }
 
     #[test]
     fn test_add() {


### PR DESCRIPTION
### What
Move Binary serialize/deserialize into traits onto all the types.

### Why
So that the more natural `my_value.serialize(&env)` that is more similar to the interfaces that libraries like serde provide, and can be used instead of `env.serialize_to_binary`.

For #173