### PR TITLE
Make Env default empty recording storage

### DIFF
--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -50,9 +50,23 @@ impl<C> IntoTryFromVal for C where C: IntoVal<Env, RawVal> + TryFromVal<Env, Raw
 
 use crate::binary::{ArrayBinary, Binary};
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct Env {
     env_impl: internal::EnvImpl,
+}
+
+impl Default for Env {
+    #[cfg(not(feature = "testutils"))]
+    fn default() -> Self {
+        Self {
+            env_impl: Default::default(),
+        }
+    }
+
+    #[cfg(feature = "testutils")]
+    fn default() -> Self {
+        Self::with_empty_recording_storage()
+    }
 }
 
 impl Env {
@@ -216,7 +230,7 @@ use std::rc::Rc;
 #[cfg(feature = "testutils")]
 #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
 impl Env {
-    pub fn with_empty_recording_storage() -> Env {
+    fn with_empty_recording_storage() -> Env {
         struct EmptySnapshotSource();
 
         impl internal::storage::SnapshotSource for EmptySnapshotSource {

--- a/sdk/tests/assert_panic.rs
+++ b/sdk/tests/assert_panic.rs
@@ -6,34 +6,34 @@ use stellar_xdr::ScHostStorageErrorCode;
 
 #[test]
 fn test_assert_panic_with_status() {
-    let e = Env::with_empty_recording_storage();
+    let e = Env::default();
     let status: Status = ScHostStorageErrorCode::AccessToUnknownEntry.into();
     e.assert_panic_with_status(status, |_env| panic_any(status));
 }
 
 #[test]
 fn test_assert_panic_with_string() {
-    let e = Env::with_empty_recording_storage();
+    let e = Env::default();
     e.assert_panic_with_string("oh no", |_env| panic!("oh no"));
 }
 
 #[test]
 fn test_assert_panic_with_fmt_string() {
-    let e = Env::with_empty_recording_storage();
+    let e = Env::default();
     e.assert_panic_with_string("oh no 123", |_env| panic!("oh no {}", 123));
 }
 
 #[test]
 #[should_panic]
 fn test_assert_panic_wrong_string() {
-    let e = Env::with_empty_recording_storage();
+    let e = Env::default();
     e.assert_panic_with_string("oh no", |_env| panic!("and yet"));
 }
 
 #[test]
 #[should_panic]
 fn test_assert_panic_with_wrong_status() {
-    let e = Env::with_empty_recording_storage();
+    let e = Env::default();
     let expected: Status = ScHostStorageErrorCode::AccessToUnknownEntry.into();
     let got: Status = ScHostStorageErrorCode::GetOnDeletedKey.into();
     e.assert_panic_with_status(expected, |_env| panic_any(got));
@@ -42,7 +42,7 @@ fn test_assert_panic_with_wrong_status() {
 #[test]
 #[should_panic]
 fn test_assert_panic_with_wrong_type() {
-    let e = Env::with_empty_recording_storage();
+    let e = Env::default();
     let expected: Status = ScHostStorageErrorCode::AccessToUnknownEntry.into();
     e.assert_panic_with_status(expected, |_env| panic_any(10));
 }


### PR DESCRIPTION
### What
Make Env::default() an have an empty recording storage when testutils enabled.

### Why
To take some subtle details away from setting up the Env in tests.

There will be reasons to expose this in the near future and to provide greater control over footprint setup, etc, but it feels confusing and unnecessary to do that now since we don't have any other infrastructure for letting a user do that. This is essentially hiding the function for the moment but gaining the functionality through default in tests.

For #173