### PR TITLE
Make UDT ScMaps sorted

### DIFF
--- a/macros/src/derive_type.rs
+++ b/macros/src/derive_type.rs
@@ -167,9 +167,9 @@ pub fn derive_type_struct(ident: &Ident, data: &DataStruct, spec: bool) -> Token
             #[inline(always)]
             fn try_into(self) -> Result<stellar_contract_sdk::xdr::ScMap, Self::Error> {
                 extern crate alloc;
-                Ok(stellar_contract_sdk::xdr::ScMap(alloc::vec![
+                Ok(stellar_contract_sdk::xdr::ScMap::sorted_from(alloc::vec![
                     #(#into_xdrs,)*
-                ].try_into()?))
+                ])?)
             }
         }
 


### PR DESCRIPTION
### What
Sort the ScMap's that are generated from user-defined types.

### Why
If they aren't sorted they're invalid. If they aren't sorted it can cause many different problems for applications that do things with the serialized version of the map. One example is signing or hashing the structure will be inconsistent with the host version which is always sorted internally.