### PR TITLE
Rename ArrayBinary to FixedBinary

### DIFF
--- a/sdk/src/binary.rs
+++ b/sdk/src/binary.rs
@@ -407,9 +407,9 @@ impl ExactSizeIterator for BinIter {
 
 #[derive(Clone)]
 #[repr(transparent)]
-pub struct ArrayBinary<const N: u32>(Binary);
+pub struct FixedBinary<const N: u32>(Binary);
 
-impl<const N: u32> Debug for ArrayBinary<N> {
+impl<const N: u32> Debug for FixedBinary<N> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "ArrayBinary{{length = {}, ", N)?;
         write!(f, "{:?}}}", self.0)?;
@@ -417,51 +417,51 @@ impl<const N: u32> Debug for ArrayBinary<N> {
     }
 }
 
-impl<const N: u32> Eq for ArrayBinary<N> {}
+impl<const N: u32> Eq for FixedBinary<N> {}
 
-impl<const N: u32> PartialEq for ArrayBinary<N> {
+impl<const N: u32> PartialEq for FixedBinary<N> {
     fn eq(&self, other: &Self) -> bool {
         self.partial_cmp(other) == Some(Ordering::Equal)
     }
 }
 
-impl<const N: u32> PartialOrd for ArrayBinary<N> {
+impl<const N: u32> PartialOrd for FixedBinary<N> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(Ord::cmp(self, other))
     }
 }
 
-impl<const N: u32> Ord for ArrayBinary<N> {
+impl<const N: u32> Ord for FixedBinary<N> {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.0.cmp(&other.0)
     }
 }
 
-impl<const N: u32> Borrow<Binary> for ArrayBinary<N> {
+impl<const N: u32> Borrow<Binary> for FixedBinary<N> {
     fn borrow(&self) -> &Binary {
         &self.0
     }
 }
 
-impl<const N: u32> Borrow<Binary> for &ArrayBinary<N> {
+impl<const N: u32> Borrow<Binary> for &FixedBinary<N> {
     fn borrow(&self) -> &Binary {
         &self.0
     }
 }
 
-impl<const N: u32> Borrow<Binary> for &mut ArrayBinary<N> {
+impl<const N: u32> Borrow<Binary> for &mut FixedBinary<N> {
     fn borrow(&self) -> &Binary {
         &self.0
     }
 }
 
-impl<const N: u32> AsRef<Binary> for ArrayBinary<N> {
+impl<const N: u32> AsRef<Binary> for FixedBinary<N> {
     fn as_ref(&self) -> &Binary {
         &self.0
     }
 }
 
-impl<const N: usize, const M: u32> TryFrom<EnvType<[u8; N]>> for ArrayBinary<M> {
+impl<const N: usize, const M: u32> TryFrom<EnvType<[u8; N]>> for FixedBinary<M> {
     type Error = ConversionError;
 
     fn try_from(ev: EnvType<[u8; N]>) -> Result<Self, Self::Error> {
@@ -480,7 +480,7 @@ impl<const N: usize, const M: u32> TryFrom<EnvType<[u8; N]>> for ArrayBinary<M> 
     }
 }
 
-impl<const N: u32> TryFrom<EnvVal> for ArrayBinary<N> {
+impl<const N: u32> TryFrom<EnvVal> for FixedBinary<N> {
     type Error = ConversionError;
 
     #[inline(always)]
@@ -490,7 +490,7 @@ impl<const N: u32> TryFrom<EnvVal> for ArrayBinary<N> {
     }
 }
 
-impl<const N: u32> TryFrom<EnvObj> for ArrayBinary<N> {
+impl<const N: u32> TryFrom<EnvObj> for FixedBinary<N> {
     type Error = ConversionError;
 
     #[inline(always)]
@@ -500,7 +500,7 @@ impl<const N: u32> TryFrom<EnvObj> for ArrayBinary<N> {
     }
 }
 
-impl<const N: u32> TryFrom<Binary> for ArrayBinary<N> {
+impl<const N: u32> TryFrom<Binary> for FixedBinary<N> {
     type Error = ConversionError;
 
     #[inline(always)]
@@ -513,61 +513,61 @@ impl<const N: u32> TryFrom<Binary> for ArrayBinary<N> {
     }
 }
 
-impl<const N: u32> From<ArrayBinary<N>> for RawVal {
+impl<const N: u32> From<FixedBinary<N>> for RawVal {
     #[inline(always)]
-    fn from(v: ArrayBinary<N>) -> Self {
+    fn from(v: FixedBinary<N>) -> Self {
         v.0.into()
     }
 }
 
-impl<const N: u32> From<ArrayBinary<N>> for EnvVal {
+impl<const N: u32> From<FixedBinary<N>> for EnvVal {
     #[inline(always)]
-    fn from(v: ArrayBinary<N>) -> Self {
+    fn from(v: FixedBinary<N>) -> Self {
         v.0.into()
     }
 }
 
-impl<const N: u32> From<ArrayBinary<N>> for EnvObj {
+impl<const N: u32> From<FixedBinary<N>> for EnvObj {
     #[inline(always)]
-    fn from(v: ArrayBinary<N>) -> Self {
+    fn from(v: FixedBinary<N>) -> Self {
         v.0.into()
     }
 }
 
-impl<const N: u32> From<ArrayBinary<N>> for Binary {
+impl<const N: u32> From<FixedBinary<N>> for Binary {
     #[inline(always)]
-    fn from(v: ArrayBinary<N>) -> Self {
+    fn from(v: FixedBinary<N>) -> Self {
         v.0
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
-impl<const N: u32> TryFrom<&ArrayBinary<N>> for ScVal {
+impl<const N: u32> TryFrom<&FixedBinary<N>> for ScVal {
     type Error = ConversionError;
-    fn try_from(v: &ArrayBinary<N>) -> Result<Self, Self::Error> {
+    fn try_from(v: &FixedBinary<N>) -> Result<Self, Self::Error> {
         (&v.0).try_into().map_err(|_| ConversionError)
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
-impl<const N: u32> TryFrom<ArrayBinary<N>> for ScVal {
+impl<const N: u32> TryFrom<FixedBinary<N>> for ScVal {
     type Error = ConversionError;
-    fn try_from(v: ArrayBinary<N>) -> Result<Self, Self::Error> {
+    fn try_from(v: FixedBinary<N>) -> Result<Self, Self::Error> {
         (&v).try_into()
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
-impl<const N: u32> TryFrom<EnvType<ScVal>> for ArrayBinary<N> {
+impl<const N: u32> TryFrom<EnvType<ScVal>> for FixedBinary<N> {
     type Error = ConversionError;
     fn try_from(v: EnvType<ScVal>) -> Result<Self, Self::Error> {
         v.try_into()
     }
 }
 
-impl<const N: u32> ArrayBinary<N> {
+impl<const N: u32> FixedBinary<N> {
     #[inline(always)]
-    pub fn from_array<const M: usize>(env: &Env, items: [u8; M]) -> ArrayBinary<N> {
+    pub fn from_array<const M: usize>(env: &Env, items: [u8; M]) -> FixedBinary<N> {
         Binary::from_array(env, items).try_into().unwrap()
     }
 
@@ -621,7 +621,7 @@ impl<const N: u32> ArrayBinary<N> {
     }
 }
 
-impl<const N: u32> IntoIterator for ArrayBinary<N> {
+impl<const N: u32> IntoIterator for FixedBinary<N> {
     type Item = u8;
 
     type IntoIter = BinIter;
@@ -665,9 +665,9 @@ mod test {
         bin_copy.pop();
         assert!(bin == bin_copy);
 
-        let bad_fixed: Result<ArrayBinary<4>, ConversionError> = bin.try_into();
+        let bad_fixed: Result<FixedBinary<4>, ConversionError> = bin.try_into();
         assert!(bad_fixed.is_err());
-        let fixed: ArrayBinary<3> = bin_copy.try_into().unwrap();
+        let fixed: FixedBinary<3> = bin_copy.try_into().unwrap();
         println!("{:?}", fixed);
     }
 
@@ -691,7 +691,7 @@ mod test {
         assert_eq!(iter.next_back(), None);
         assert_eq!(iter.next_back(), None);
 
-        let fixed: ArrayBinary<3> = bin.try_into().unwrap();
+        let fixed: FixedBinary<3> = bin.try_into().unwrap();
         let mut iter = fixed.iter();
         assert_eq!(iter.next(), Some(10));
         assert_eq!(iter.next(), Some(20));
@@ -720,7 +720,7 @@ mod test {
         bin.push(30);
         assert_eq!(bin.len(), 3);
 
-        let arr_bin: ArrayBinary<3> = bin.clone().try_into().unwrap();
+        let arr_bin: FixedBinary<3> = bin.clone().try_into().unwrap();
         assert_eq!(arr_bin.len(), 3);
 
         assert_eq!(get_len(&bin), 3);

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -48,7 +48,7 @@ pub type EnvObj = internal::EnvVal<Env, Object>;
 pub trait IntoTryFromVal: IntoVal<Env, RawVal> + TryFromVal<Env, RawVal> {}
 impl<C> IntoTryFromVal for C where C: IntoVal<Env, RawVal> + TryFromVal<Env, RawVal> {}
 
-use crate::binary::{ArrayBinary, Binary};
+use crate::binary::{Binary, FixedBinary};
 
 #[derive(Clone)]
 pub struct Env {
@@ -85,14 +85,14 @@ impl Env {
         T::try_from_val(&self, rv).map_err(|_| ()).unwrap()
     }
 
-    pub fn get_current_contract(&self) -> ArrayBinary<32> {
+    pub fn get_current_contract(&self) -> FixedBinary<32> {
         internal::Env::get_current_contract(self)
             .in_env(self)
             .try_into()
             .unwrap()
     }
 
-    pub fn get_invoking_contract(&self) -> ArrayBinary<32> {
+    pub fn get_invoking_contract(&self) -> FixedBinary<32> {
         let rv = internal::Env::get_invoking_contract(self).to_raw();
         let bin = Binary::try_from_val(self, rv).unwrap();
         bin.try_into().unwrap()
@@ -167,7 +167,7 @@ impl Env {
     }
 
     #[doc(hidden)]
-    pub fn create_contract_from_contract(&self, contract: Binary, salt: Binary) -> ArrayBinary<32> {
+    pub fn create_contract_from_contract(&self, contract: Binary, salt: Binary) -> FixedBinary<32> {
         let contract_obj: Object = RawVal::from(contract).try_into().unwrap();
         let salt_obj: Object = RawVal::from(salt).try_into().unwrap();
         let id_obj = internal::Env::create_contract_from_contract(self, contract_obj, salt_obj);

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -44,7 +44,7 @@ pub mod iter;
 mod map;
 mod vec;
 pub use bigint::BigInt;
-pub use binary::{ArrayBinary, Binary};
+pub use binary::{Binary, FixedBinary};
 pub use map::Map;
 pub use vec::Vec;
 


### PR DESCRIPTION
### What
Rename ArrayBinary to FixedBinary.

### Why
There's an ArrayVec type in a popular crate that provides particular semantics about what it means for an Array type, i.e. it is backed by an array. This type of ours is not backed by an array, it's still backed by the host it just guarantees the internal size to be a fixed size. Given that we talked about potentially adding other types in the future that are backed by different things like an array I think we should avoid the term array on this type since it might be misleading and confusing in the future. Especially if we also encourage use of ArrayVec.