### PR TITLE
Change u32 to usize for indexes and lengths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: check build test
 
-export RUSTFLAGS=-Dwarnings
+export RUSTFLAGS=-Dwarnings -A clippy::all -D clippy::cast_possible_truncation -D clippy::cast_possible_wrap -D clippy::cast_precision_loss -D clippy::cast_sign_loss
 
 doc:
 	cargo +nightly doc --open --no-deps \
@@ -27,7 +27,7 @@ build:
 		done
 
 check: fmt
-	cargo hack --feature-powerset --exclude-features docs check --all-targets
+	cargo hack --feature-powerset --exclude-features docs clippy --all-targets
 	cargo check --release --target wasm32-unknown-unknown
 
 watch:

--- a/sdk/src/binary.rs
+++ b/sdk/src/binary.rs
@@ -618,7 +618,7 @@ impl<const N: usize> FixedBinary<N> {
     }
 }
 
-impl<const N: u32> IntoIterator for FixedBinary<N> {
+impl<const N: usize> IntoIterator for FixedBinary<N> {
     type Item = u8;
 
     type IntoIter = BinIter;

--- a/sdk/src/binary.rs
+++ b/sdk/src/binary.rs
@@ -6,6 +6,8 @@ use core::{
     ops::{Bound, RangeBounds},
 };
 
+use crate::u32usize::u32_to_usize;
+
 use super::{
     env::internal::Env as _, env::EnvType, xdr::ScObjectType, ConversionError, Env, EnvObj, EnvVal,
     Object, RawVal, RawValConvertible,
@@ -212,7 +214,7 @@ impl Binary {
     pub fn len(&self) -> usize {
         let env = self.env();
         let val = env.binary_len(self.0.to_tagged());
-        u32::try_from(val).unwrap() as usize
+        u32_to_usize(u32::try_from(val).unwrap())
     }
 
     #[inline(always)]
@@ -378,6 +380,7 @@ impl Iterator for BinIter {
         } else {
             let val = self.0.env().binary_front(self.0 .0.to_object());
             self.0 = self.0.slice(1..);
+            #[allow(clippy::cast_possible_truncation)]
             let val = unsafe { <u32 as RawValConvertible>::unchecked_from_val(val) } as u8;
             Some(val)
         }
@@ -397,6 +400,7 @@ impl DoubleEndedIterator for BinIter {
         } else {
             let val = self.0.env().binary_back(self.0 .0.to_object());
             self.0 = self.0.slice(..len - 1);
+            #[allow(clippy::cast_possible_truncation)]
             let val = unsafe { <u32 as RawValConvertible>::unchecked_from_val(val) } as u8;
             Some(val)
         }

--- a/sdk/src/binary.rs
+++ b/sdk/src/binary.rs
@@ -175,7 +175,7 @@ impl Binary {
 
     #[inline(always)]
     pub fn set(&mut self, i: usize, v: u8) {
-        let i: u32 = v.try_into().unwrap();
+        let i: u32 = i.try_into().unwrap();
         let v32: u32 = v.into();
         self.0 = self
             .env()
@@ -705,7 +705,7 @@ mod test {
 
     #[test]
     fn test_array_binary_borrow() {
-        fn get_len(b: impl Borrow<Binary>) -> u32 {
+        fn get_len(b: impl Borrow<Binary>) -> usize {
             let b: &Binary = b.borrow();
             b.len()
         }

--- a/sdk/src/binary.rs
+++ b/sdk/src/binary.rs
@@ -413,9 +413,9 @@ impl ExactSizeIterator for BinIter {
 
 #[derive(Clone)]
 #[repr(transparent)]
-pub struct FixedBinary<const N: u32>(Binary);
+pub struct FixedBinary<const N: usize>(Binary);
 
-impl<const N: u32> Debug for FixedBinary<N> {
+impl<const N: usize> Debug for FixedBinary<N> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "ArrayBinary{{length = {}, ", N)?;
         write!(f, "{:?}}}", self.0)?;
@@ -423,70 +423,61 @@ impl<const N: u32> Debug for FixedBinary<N> {
     }
 }
 
-impl<const N: u32> Eq for FixedBinary<N> {}
+impl<const N: usize> Eq for FixedBinary<N> {}
 
-impl<const N: u32> PartialEq for FixedBinary<N> {
+impl<const N: usize> PartialEq for FixedBinary<N> {
     fn eq(&self, other: &Self) -> bool {
         self.partial_cmp(other) == Some(Ordering::Equal)
     }
 }
 
-impl<const N: u32> PartialOrd for FixedBinary<N> {
+impl<const N: usize> PartialOrd for FixedBinary<N> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(Ord::cmp(self, other))
     }
 }
 
-impl<const N: u32> Ord for FixedBinary<N> {
+impl<const N: usize> Ord for FixedBinary<N> {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.0.cmp(&other.0)
     }
 }
 
-impl<const N: u32> Borrow<Binary> for FixedBinary<N> {
+impl<const N: usize> Borrow<Binary> for FixedBinary<N> {
     fn borrow(&self) -> &Binary {
         &self.0
     }
 }
 
-impl<const N: u32> Borrow<Binary> for &FixedBinary<N> {
+impl<const N: usize> Borrow<Binary> for &FixedBinary<N> {
     fn borrow(&self) -> &Binary {
         &self.0
     }
 }
 
-impl<const N: u32> Borrow<Binary> for &mut FixedBinary<N> {
+impl<const N: usize> Borrow<Binary> for &mut FixedBinary<N> {
     fn borrow(&self) -> &Binary {
         &self.0
     }
 }
 
-impl<const N: u32> AsRef<Binary> for FixedBinary<N> {
+impl<const N: usize> AsRef<Binary> for FixedBinary<N> {
     fn as_ref(&self) -> &Binary {
         &self.0
     }
 }
 
-impl<const N: usize, const M: u32> TryFrom<EnvType<[u8; N]>> for FixedBinary<M> {
-    type Error = ConversionError;
-
-    fn try_from(ev: EnvType<[u8; N]>) -> Result<Self, Self::Error> {
-        // TODO: Reconsider u32 as the length type of ArrayBinary (and other
-        // types like Vec too). The size cannot be guaranteed at compile time
-        // because of the usize / u32 type difference of the size of arrays and
-        // the const generic on the type.
-        if M as usize != N {
-            return Err(ConversionError);
-        }
+impl<const N: usize> From<EnvType<[u8; N]>> for FixedBinary<N> {
+    fn from(ev: EnvType<[u8; N]>) -> Self {
         let mut bin = Binary::new(&ev.env);
         for b in ev.val {
             bin.push(b);
         }
-        bin.try_into()
+        FixedBinary::<N>(bin)
     }
 }
 
-impl<const N: u32> TryFrom<EnvVal> for FixedBinary<N> {
+impl<const N: usize> TryFrom<EnvVal> for FixedBinary<N> {
     type Error = ConversionError;
 
     #[inline(always)]
@@ -496,7 +487,7 @@ impl<const N: u32> TryFrom<EnvVal> for FixedBinary<N> {
     }
 }
 
-impl<const N: u32> TryFrom<EnvObj> for FixedBinary<N> {
+impl<const N: usize> TryFrom<EnvObj> for FixedBinary<N> {
     type Error = ConversionError;
 
     #[inline(always)]
@@ -506,7 +497,7 @@ impl<const N: u32> TryFrom<EnvObj> for FixedBinary<N> {
     }
 }
 
-impl<const N: u32> TryFrom<Binary> for FixedBinary<N> {
+impl<const N: usize> TryFrom<Binary> for FixedBinary<N> {
     type Error = ConversionError;
 
     #[inline(always)]
@@ -519,28 +510,28 @@ impl<const N: u32> TryFrom<Binary> for FixedBinary<N> {
     }
 }
 
-impl<const N: u32> From<FixedBinary<N>> for RawVal {
+impl<const N: usize> From<FixedBinary<N>> for RawVal {
     #[inline(always)]
     fn from(v: FixedBinary<N>) -> Self {
         v.0.into()
     }
 }
 
-impl<const N: u32> From<FixedBinary<N>> for EnvVal {
+impl<const N: usize> From<FixedBinary<N>> for EnvVal {
     #[inline(always)]
     fn from(v: FixedBinary<N>) -> Self {
         v.0.into()
     }
 }
 
-impl<const N: u32> From<FixedBinary<N>> for EnvObj {
+impl<const N: usize> From<FixedBinary<N>> for EnvObj {
     #[inline(always)]
     fn from(v: FixedBinary<N>) -> Self {
         v.0.into()
     }
 }
 
-impl<const N: u32> From<FixedBinary<N>> for Binary {
+impl<const N: usize> From<FixedBinary<N>> for Binary {
     #[inline(always)]
     fn from(v: FixedBinary<N>) -> Self {
         v.0
@@ -548,7 +539,7 @@ impl<const N: u32> From<FixedBinary<N>> for Binary {
 }
 
 #[cfg(not(target_family = "wasm"))]
-impl<const N: u32> TryFrom<&FixedBinary<N>> for ScVal {
+impl<const N: usize> TryFrom<&FixedBinary<N>> for ScVal {
     type Error = ConversionError;
     fn try_from(v: &FixedBinary<N>) -> Result<Self, Self::Error> {
         (&v.0).try_into().map_err(|_| ConversionError)
@@ -556,7 +547,7 @@ impl<const N: u32> TryFrom<&FixedBinary<N>> for ScVal {
 }
 
 #[cfg(not(target_family = "wasm"))]
-impl<const N: u32> TryFrom<FixedBinary<N>> for ScVal {
+impl<const N: usize> TryFrom<FixedBinary<N>> for ScVal {
     type Error = ConversionError;
     fn try_from(v: FixedBinary<N>) -> Result<Self, Self::Error> {
         (&v).try_into()
@@ -564,31 +555,31 @@ impl<const N: u32> TryFrom<FixedBinary<N>> for ScVal {
 }
 
 #[cfg(not(target_family = "wasm"))]
-impl<const N: u32> TryFrom<EnvType<ScVal>> for FixedBinary<N> {
+impl<const N: usize> TryFrom<EnvType<ScVal>> for FixedBinary<N> {
     type Error = ConversionError;
     fn try_from(v: EnvType<ScVal>) -> Result<Self, Self::Error> {
         v.try_into()
     }
 }
 
-impl<const N: u32> FixedBinary<N> {
+impl<const N: usize> FixedBinary<N> {
     #[inline(always)]
     pub fn from_array<const M: usize>(env: &Env, items: [u8; M]) -> FixedBinary<N> {
         Binary::from_array(env, items).try_into().unwrap()
     }
 
     #[inline(always)]
-    pub fn set(&mut self, i: u32, v: u8) {
+    pub fn set(&mut self, i: usize, v: u8) {
         self.0.set(i, v);
     }
 
     #[inline(always)]
-    pub fn get(&self, i: u32) -> Option<u8> {
+    pub fn get(&self, i: usize) -> Option<u8> {
         self.0.get(i)
     }
 
     #[inline(always)]
-    pub fn get_unchecked(&self, i: u32) -> u8 {
+    pub fn get_unchecked(&self, i: usize) -> u8 {
         self.0.get_unchecked(i)
     }
 
@@ -598,7 +589,7 @@ impl<const N: u32> FixedBinary<N> {
     }
 
     #[inline(always)]
-    pub fn len(&self) -> u32 {
+    pub fn len(&self) -> usize {
         N
     }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -9,6 +9,8 @@
 #[cfg(target_family = "wasm")]
 use stellar_contract_env_panic_handler_wasm32_unreachable as _;
 
+mod u32usize;
+
 #[cfg_attr(target_family = "wasm", link_section = "contractenvmetav0")]
 static ENV_META_XDR: [u8; env::meta::XDR.len()] = env::meta::XDR;
 

--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -1,6 +1,9 @@
 use core::{cmp::Ordering, fmt::Debug, iter::FusedIterator, marker::PhantomData};
 
-use crate::iter::{UncheckedEnumerable, UncheckedIter};
+use crate::{
+    iter::{UncheckedEnumerable, UncheckedIter},
+    u32usize::u32_to_usize,
+};
 
 use super::{
     env::internal::Env as _, xdr::ScObjectType, ConversionError, Env, EnvObj, EnvVal,
@@ -235,7 +238,7 @@ impl<K: IntoTryFromVal, V: IntoTryFromVal> Map<K, V> {
     pub fn len(&self) -> usize {
         let env = self.env();
         let len = env.map_len(self.0.to_tagged());
-        u32::try_from_val(env, len).unwrap() as usize
+        u32_to_usize(u32::try_from_val(env, len).unwrap())
     }
 
     #[inline(always)]
@@ -381,7 +384,7 @@ where
     V: IntoTryFromVal,
 {
     fn len(&self) -> usize {
-        self.0.len() as usize
+        self.0.len()
     }
 }
 

--- a/sdk/src/map.rs
+++ b/sdk/src/map.rs
@@ -232,10 +232,10 @@ impl<K: IntoTryFromVal, V: IntoTryFromVal> Map<K, V> {
     }
 
     #[inline(always)]
-    pub fn len(&self) -> u32 {
+    pub fn len(&self) -> usize {
         let env = self.env();
         let len = env.map_len(self.0.to_tagged());
-        u32::try_from_val(env, len).unwrap()
+        u32::try_from_val(env, len).unwrap() as usize
     }
 
     #[inline(always)]
@@ -333,7 +333,7 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.0.len() as usize;
+        let len = self.0.len();
         (len, Some(len))
     }
 

--- a/sdk/src/u32usize.rs
+++ b/sdk/src/u32usize.rs
@@ -1,0 +1,19 @@
+#[cfg(target_pointer_width = "32")]
+pub fn usize_to_u32(u: usize) -> Option<u32> {
+    Some(u as u32)
+}
+
+#[cfg(target_pointer_width = "64")]
+pub fn usize_to_u32(u: usize) -> Option<u32> {
+    u.try_into().ok()
+}
+
+#[cfg(target_pointer_width = "32")]
+pub fn u32_to_usize(u: u32) -> usize {
+    u as usize
+}
+
+#[cfg(target_pointer_width = "64")]
+pub fn u32_to_usize(u: u32) -> usize {
+    u as usize
+}

--- a/tests/linear_memory/src/lib.rs
+++ b/tests/linear_memory/src/lib.rs
@@ -23,7 +23,7 @@ impl Contract {
         let lm_pos: u32 = unsafe { buf.as_ptr().add(buf_off as usize) as u32 };
         e.binary_copy_to_linear_memory(b.clone(), b_pos, lm_pos, len);
         for idx in lm_pos..buf.len() as u32 {
-            assert!(buf[idx as usize] == b.get_unchecked(b_pos + idx));
+            assert!(buf[idx as usize] == b.get_unchecked((b_pos + idx) as usize));
         }
     }
 }

--- a/tests/linear_memory/src/lib.rs
+++ b/tests/linear_memory/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::cast_possible_truncation)]
 #![no_std]
 use stellar_contract_sdk::{contractimpl, Binary, Env};
 


### PR DESCRIPTION
### What
Change u32 to usize for indexes and lengths of collections.

### Why
It is inconvenient that the lengths and indexes of these types are not usize. For example, if I create conversion from a fixed size array to a Vec, or a Binary, I can't do so relying on the contract to guarantee that the size of both, for fixed size structures, are identical. I have to rely on a runtime check. In general it seems a bit odd we'd not use usize at the seams, assuming there's not some cost to doing so.

### Affect on Contract Size

For some reason the `create_contract` test went down in size, unclear why.

As expected the `linear_memory` test went up in size, likely due to the additional `u32::MAX` checks, not substantially though.

#### Before
```-rw-r--r--  1 leighmcculloch  staff  345 Jul 25 17:31 example_add_i32.wasm
-rw-r--r--  1 leighmcculloch  staff  541 Jul 25 17:31 example_add_i64.wasm
-rw-r--r--  1 leighmcculloch  staff  617 Jul 25 17:31 example_contract_data.wasm
-rw-r--r--  1 leighmcculloch  staff  566 Jul 25 17:31 example_create_contract.wasm
-rw-r--r--  1 leighmcculloch  staff  1163 Jul 25 17:31 example_linear_memory.wasm
-rw-r--r--  1 leighmcculloch  staff  2121 Jul 25 17:31 example_udt.wasm
-rw-r--r--  1 leighmcculloch  staff  103 Jul 25 17:31 stellar_contract_sdk.wasm
```

#### After
```-rw-r--r--  1 leighmcculloch  staff  345 Jul 25 17:30 example_add_i32.wasm
-rw-r--r--  1 leighmcculloch  staff  541 Jul 25 17:30 example_add_i64.wasm
-rw-r--r--  1 leighmcculloch  staff  617 Jul 25 17:30 example_contract_data.wasm
-rw-r--r--  1 leighmcculloch  staff  548 Jul 25 17:30 example_create_contract.wasm
-rw-r--r--  1 leighmcculloch  staff  1197 Jul 25 17:30 example_linear_memory.wasm
-rw-r--r--  1 leighmcculloch  staff  2121 Jul 25 17:30 example_udt.wasm
-rw-r--r--  1 leighmcculloch  staff  103 Jul 25 17:30 stellar_contract_sdk.wasm
```