### PR TITLE
Limit exported xdr types to relevant types

### DIFF
--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -23,8 +23,23 @@ pub mod internal {
     }
 }
 
+pub mod xdr {
+    #[cfg(not(target_family = "wasm"))]
+    pub use super::internal::xdr::ReadXdrIter;
+    pub use super::internal::xdr::{Error, ReadXdr, Validate, VecM, WriteXdr};
+    pub use super::internal::xdr::{
+        ScBigInt, ScEnvMetaEntry, ScEnvMetaKind, ScHash, ScHashType, ScHostContextErrorCode,
+        ScHostFnErrorCode, ScHostObjErrorCode, ScHostStorageErrorCode, ScHostValErrorCode, ScMap,
+        ScMapEntry, ScNumSign, ScObject, ScObjectType, ScSpecEntry, ScSpecEntryKind,
+        ScSpecFunctionV0, ScSpecType, ScSpecTypeDef, ScSpecTypeMap, ScSpecTypeOption,
+        ScSpecTypeResult, ScSpecTypeSet, ScSpecTypeTuple, ScSpecTypeUdt, ScSpecTypeVec,
+        ScSpecUdtStructFieldV0, ScSpecUdtStructV0, ScSpecUdtUnionCaseV0, ScSpecUdtUnionV0,
+        ScStatic, ScStatus, ScStatusType, ScSymbol, ScUnknownErrorCode, ScVal, ScValType, ScVec,
+        ScVmErrorCode,
+    };
+}
+
 pub use internal::meta;
-pub use internal::xdr;
 pub use internal::BitSet;
 pub use internal::ConversionError;
 pub use internal::EnvBase;
@@ -230,8 +245,9 @@ impl Env {
         impl internal::storage::SnapshotSource for EmptySnapshotSource {
             fn get(
                 &self,
-                _key: &xdr::LedgerKey,
-            ) -> Result<xdr::LedgerEntry, stellar_contract_env_host::HostError> {
+                _key: &internal::xdr::LedgerKey,
+            ) -> Result<internal::xdr::LedgerEntry, stellar_contract_env_host::HostError>
+            {
                 use xdr::{ScHostStorageErrorCode, ScStatus};
                 let status: internal::Status =
                     ScStatus::HostStorageError(ScHostStorageErrorCode::UnknownError).into();
@@ -240,7 +256,7 @@ impl Env {
 
             fn has(
                 &self,
-                _key: &xdr::LedgerKey,
+                _key: &internal::xdr::LedgerKey,
             ) -> Result<bool, stellar_contract_env_host::HostError> {
                 Ok(false)
             }
@@ -276,7 +292,11 @@ impl Env {
             .unwrap();
     }
 
-    pub fn invoke_contract(&mut self, hf: xdr::HostFunction, args: xdr::ScVec) -> xdr::ScVal {
+    pub fn invoke_contract(
+        &mut self,
+        hf: internal::xdr::HostFunction,
+        args: xdr::ScVec,
+    ) -> xdr::ScVal {
         self.env_impl.invoke_function(hf, args).unwrap()
     }
 

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -23,23 +23,8 @@ pub mod internal {
     }
 }
 
-pub mod xdr {
-    #[cfg(not(target_family = "wasm"))]
-    pub use super::internal::xdr::ReadXdrIter;
-    pub use super::internal::xdr::{Error, ReadXdr, Validate, VecM, WriteXdr};
-    pub use super::internal::xdr::{
-        ScBigInt, ScEnvMetaEntry, ScEnvMetaKind, ScHash, ScHashType, ScHostContextErrorCode,
-        ScHostFnErrorCode, ScHostObjErrorCode, ScHostStorageErrorCode, ScHostValErrorCode, ScMap,
-        ScMapEntry, ScNumSign, ScObject, ScObjectType, ScSpecEntry, ScSpecEntryKind,
-        ScSpecFunctionV0, ScSpecType, ScSpecTypeDef, ScSpecTypeMap, ScSpecTypeOption,
-        ScSpecTypeResult, ScSpecTypeSet, ScSpecTypeTuple, ScSpecTypeUdt, ScSpecTypeVec,
-        ScSpecUdtStructFieldV0, ScSpecUdtStructV0, ScSpecUdtUnionCaseV0, ScSpecUdtUnionV0,
-        ScStatic, ScStatus, ScStatusType, ScSymbol, ScUnknownErrorCode, ScVal, ScValType, ScVec,
-        ScVmErrorCode,
-    };
-}
-
 pub use internal::meta;
+pub use internal::xdr;
 pub use internal::BitSet;
 pub use internal::ConversionError;
 pub use internal::EnvBase;
@@ -245,9 +230,8 @@ impl Env {
         impl internal::storage::SnapshotSource for EmptySnapshotSource {
             fn get(
                 &self,
-                _key: &internal::xdr::LedgerKey,
-            ) -> Result<internal::xdr::LedgerEntry, stellar_contract_env_host::HostError>
-            {
+                _key: &xdr::LedgerKey,
+            ) -> Result<xdr::LedgerEntry, stellar_contract_env_host::HostError> {
                 use xdr::{ScHostStorageErrorCode, ScStatus};
                 let status: internal::Status =
                     ScStatus::HostStorageError(ScHostStorageErrorCode::UnknownError).into();
@@ -256,7 +240,7 @@ impl Env {
 
             fn has(
                 &self,
-                _key: &internal::xdr::LedgerKey,
+                _key: &xdr::LedgerKey,
             ) -> Result<bool, stellar_contract_env_host::HostError> {
                 Ok(false)
             }
@@ -292,11 +276,7 @@ impl Env {
             .unwrap();
     }
 
-    pub fn invoke_contract(
-        &mut self,
-        hf: internal::xdr::HostFunction,
-        args: xdr::ScVec,
-    ) -> xdr::ScVal {
+    pub fn invoke_contract(&mut self, hf: xdr::HostFunction, args: xdr::ScVec) -> xdr::ScVal {
         self.env_impl.invoke_function(hf, args).unwrap()
     }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -15,9 +15,7 @@ static ENV_META_XDR: [u8; env::meta::XDR.len()] = env::meta::XDR;
 pub use stellar_contract_macros::{contractimpl, contracttype, ContractType};
 
 mod env;
-pub mod xdr {
-    pub use super::env::xdr::*;
-}
+pub use env::xdr;
 pub use env::BitSet;
 pub use env::ConversionError;
 pub use env::Env;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -15,7 +15,23 @@ static ENV_META_XDR: [u8; env::meta::XDR.len()] = env::meta::XDR;
 pub use stellar_contract_macros::{contractimpl, contracttype, ContractType};
 
 mod env;
-pub use env::xdr;
+
+pub mod xdr {
+    #[cfg(not(target_family = "wasm"))]
+    pub use super::env::xdr::ReadXdrIter;
+    pub use super::env::xdr::{Error, ReadXdr, Validate, VecM, WriteXdr};
+    pub use super::env::xdr::{
+        ScBigInt, ScEnvMetaEntry, ScEnvMetaKind, ScHash, ScHashType, ScHostContextErrorCode,
+        ScHostFnErrorCode, ScHostObjErrorCode, ScHostStorageErrorCode, ScHostValErrorCode, ScMap,
+        ScMapEntry, ScNumSign, ScObject, ScObjectType, ScSpecEntry, ScSpecEntryKind,
+        ScSpecFunctionV0, ScSpecType, ScSpecTypeDef, ScSpecTypeMap, ScSpecTypeOption,
+        ScSpecTypeResult, ScSpecTypeSet, ScSpecTypeTuple, ScSpecTypeUdt, ScSpecTypeVec,
+        ScSpecUdtStructFieldV0, ScSpecUdtStructV0, ScSpecUdtUnionCaseV0, ScSpecUdtUnionV0,
+        ScStatic, ScStatus, ScStatusType, ScSymbol, ScUnknownErrorCode, ScVal, ScValType, ScVec,
+        ScVmErrorCode,
+    };
+}
+
 pub use env::BitSet;
 pub use env::ConversionError;
 pub use env::Env;


### PR DESCRIPTION
### What
Limit exported xdr types to relevant types .

### Why
There's a lot of XDR types and most of them have little to nothing to do with contracts which makes them a ton of noise for little value. It'll take us a small amount of effort to keep the exported list explicit, but I think it'll be helpful.

For #173