### PR TITLE
Export xdr::HostFunction

### DIFF
--- a/sdk/src/binary.rs
+++ b/sdk/src/binary.rs
@@ -161,9 +161,7 @@ impl Binary {
 
     #[inline(always)]
     pub fn from_array<const N: usize>(env: &Env, items: [u8; N]) -> Binary {
-        let mut bin = Binary::new(env);
-        bin.extend_from_array(items);
-        bin
+        FixedBinary::from_array(env, items).0
     }
 
     #[inline(always)]
@@ -558,8 +556,10 @@ impl<const N: usize> TryFrom<EnvType<ScVal>> for FixedBinary<N> {
 
 impl<const N: usize> FixedBinary<N> {
     #[inline(always)]
-    pub fn from_array<const M: usize>(env: &Env, items: [u8; M]) -> FixedBinary<N> {
-        Binary::from_array(env, items).try_into().unwrap()
+    pub fn from_array(env: &Env, items: [u8; N]) -> FixedBinary<N> {
+        let mut bin = Binary::new(env);
+        bin.extend_from_array(items);
+        FixedBinary(bin)
     }
 
     #[inline(always)]

--- a/sdk/src/binary.rs
+++ b/sdk/src/binary.rs
@@ -161,7 +161,9 @@ impl Binary {
 
     #[inline(always)]
     pub fn from_array<const N: usize>(env: &Env, items: [u8; N]) -> Binary {
-        FixedBinary::from_array(env, items).0
+        let mut bin = Binary::new(env);
+        bin.extend_from_array(items);
+        bin
     }
 
     #[inline(always)]
@@ -556,10 +558,8 @@ impl<const N: usize> TryFrom<EnvType<ScVal>> for FixedBinary<N> {
 
 impl<const N: usize> FixedBinary<N> {
     #[inline(always)]
-    pub fn from_array(env: &Env, items: [u8; N]) -> FixedBinary<N> {
-        let mut bin = Binary::new(env);
-        bin.extend_from_array(items);
-        FixedBinary(bin)
+    pub fn from_array<const M: usize>(env: &Env, items: [u8; M]) -> FixedBinary<N> {
+        Binary::from_array(env, items).try_into().unwrap()
     }
 
     #[inline(always)]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -16,10 +16,13 @@ pub use stellar_contract_macros::{contractimpl, contracttype, ContractType};
 
 mod env;
 
+/// XDR contains types for building and generating XDR values.
 pub mod xdr {
-    #[cfg(not(target_family = "wasm"))]
-    pub use super::env::xdr::ReadXdrIter;
-    pub use super::env::xdr::{Error, ReadXdr, Validate, VecM, WriteXdr};
+    // Xdr types and traits.
+    pub use super::env::xdr::{Error, ReadXdr, ReadXdrIter, Validate, VecM, WriteXdr};
+    // Host functions.
+    pub use super::env::xdr::HostFunction;
+    // Contract types.
     pub use super::env::xdr::{
         ScBigInt, ScEnvMetaEntry, ScEnvMetaKind, ScHash, ScHashType, ScHostContextErrorCode,
         ScHostFnErrorCode, ScHostObjErrorCode, ScHostStorageErrorCode, ScHostValErrorCode, ScMap,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -27,16 +27,27 @@ pub mod xdr {
     pub use super::env::xdr::ReadXdrIter;
     pub use super::env::xdr::{Error, ReadXdr, Validate, VecM, WriteXdr};
 
-    // XDR contract specific types.
+    // XDR contract val types.
     pub use super::env::xdr::{
-        ScBigInt, ScEnvMetaEntry, ScEnvMetaKind, ScHash, ScHashType, ScHostContextErrorCode,
-        ScHostFnErrorCode, ScHostObjErrorCode, ScHostStorageErrorCode, ScHostValErrorCode, ScMap,
-        ScMapEntry, ScNumSign, ScObject, ScObjectType, ScSpecEntry, ScSpecEntryKind,
-        ScSpecFunctionV0, ScSpecType, ScSpecTypeDef, ScSpecTypeMap, ScSpecTypeOption,
-        ScSpecTypeResult, ScSpecTypeSet, ScSpecTypeTuple, ScSpecTypeUdt, ScSpecTypeVec,
-        ScSpecUdtStructFieldV0, ScSpecUdtStructV0, ScSpecUdtUnionCaseV0, ScSpecUdtUnionV0,
-        ScStatic, ScStatus, ScStatusType, ScSymbol, ScUnknownErrorCode, ScVal, ScValType, ScVec,
-        ScVmErrorCode,
+        ScBigInt, ScHash, ScHashType, ScMap, ScMapEntry, ScNumSign, ScObject, ScObjectType,
+        ScStatic, ScStatus, ScStatusType, ScSymbol, ScVal, ScValType, ScVec,
+    };
+
+    // XDR contract error codes.
+    pub use super::env::xdr::{
+        ScHostContextErrorCode, ScHostFnErrorCode, ScHostObjErrorCode, ScHostStorageErrorCode,
+        ScHostValErrorCode, ScUnknownErrorCode, ScVmErrorCode,
+    };
+
+    // XDR contract env meta types.
+    pub use super::env::xdr::{ScEnvMetaEntry, ScEnvMetaKind};
+
+    // XDR contract spec types.
+    pub use super::env::xdr::{
+        ScSpecEntry, ScSpecEntryKind, ScSpecFunctionV0, ScSpecType, ScSpecTypeDef, ScSpecTypeMap,
+        ScSpecTypeOption, ScSpecTypeResult, ScSpecTypeSet, ScSpecTypeTuple, ScSpecTypeUdt,
+        ScSpecTypeVec, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, ScSpecUdtUnionCaseV0,
+        ScSpecUdtUnionV0,
     };
 }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -18,11 +18,14 @@ mod env;
 
 /// XDR contains types for building and generating XDR values.
 pub mod xdr {
-    // Xdr types and traits.
-    pub use super::env::xdr::{Error, ReadXdr, ReadXdrIter, Validate, VecM, WriteXdr};
-    // Host functions.
+    // XDR types needed by macros.
+    #[doc(hidden)]
     pub use super::env::xdr::HostFunction;
-    // Contract types.
+
+    // XDR generic types and traits.
+    pub use super::env::xdr::{Error, ReadXdr, ReadXdrIter, Validate, VecM, WriteXdr};
+
+    // XDR contract specific types.
     pub use super::env::xdr::{
         ScBigInt, ScEnvMetaEntry, ScEnvMetaKind, ScHash, ScHashType, ScHostContextErrorCode,
         ScHostFnErrorCode, ScHostObjErrorCode, ScHostStorageErrorCode, ScHostValErrorCode, ScMap,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -16,40 +16,7 @@ pub use stellar_contract_macros::{contractimpl, contracttype, ContractType};
 
 mod env;
 
-/// XDR contains types for building and generating XDR values.
-pub mod xdr {
-    // XDR types needed by macros.
-    #[doc(hidden)]
-    pub use super::env::xdr::HostFunction;
-
-    // XDR generic types and traits.
-    #[cfg(not(target_family = "wasm"))]
-    pub use super::env::xdr::ReadXdrIter;
-    pub use super::env::xdr::{Error, ReadXdr, Validate, VecM, WriteXdr};
-
-    // XDR contract val types.
-    pub use super::env::xdr::{
-        ScBigInt, ScHash, ScHashType, ScMap, ScMapEntry, ScNumSign, ScObject, ScObjectType,
-        ScStatic, ScStatus, ScStatusType, ScSymbol, ScVal, ScValType, ScVec,
-    };
-
-    // XDR contract error codes.
-    pub use super::env::xdr::{
-        ScHostContextErrorCode, ScHostFnErrorCode, ScHostObjErrorCode, ScHostStorageErrorCode,
-        ScHostValErrorCode, ScUnknownErrorCode, ScVmErrorCode,
-    };
-
-    // XDR contract env meta types.
-    pub use super::env::xdr::{ScEnvMetaEntry, ScEnvMetaKind};
-
-    // XDR contract spec types.
-    pub use super::env::xdr::{
-        ScSpecEntry, ScSpecEntryKind, ScSpecFunctionV0, ScSpecType, ScSpecTypeDef, ScSpecTypeMap,
-        ScSpecTypeOption, ScSpecTypeResult, ScSpecTypeSet, ScSpecTypeTuple, ScSpecTypeUdt,
-        ScSpecTypeVec, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, ScSpecUdtUnionCaseV0,
-        ScSpecUdtUnionV0,
-    };
-}
+pub mod xdr;
 
 pub use env::BitSet;
 pub use env::ConversionError;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -23,7 +23,9 @@ pub mod xdr {
     pub use super::env::xdr::HostFunction;
 
     // XDR generic types and traits.
-    pub use super::env::xdr::{Error, ReadXdr, ReadXdrIter, Validate, VecM, WriteXdr};
+    #[cfg(not(target_family = "wasm"))]
+    pub use super::env::xdr::ReadXdrIter;
+    pub use super::env::xdr::{Error, ReadXdr, Validate, VecM, WriteXdr};
 
     // XDR contract specific types.
     pub use super::env::xdr::{

--- a/sdk/src/xdr.rs
+++ b/sdk/src/xdr.rs
@@ -1,0 +1,33 @@
+/// XDR contains types for building and generating XDR values.
+
+// XDR types needed by macros.
+#[doc(hidden)]
+pub use super::env::xdr::HostFunction;
+
+// XDR generic types and traits.
+#[cfg(not(target_family = "wasm"))]
+pub use super::env::xdr::ReadXdrIter;
+pub use super::env::xdr::{Error, ReadXdr, Validate, VecM, WriteXdr};
+
+// XDR contract val types.
+pub use super::env::xdr::{
+    ScBigInt, ScHash, ScHashType, ScMap, ScMapEntry, ScNumSign, ScObject, ScObjectType, ScStatic,
+    ScStatus, ScStatusType, ScSymbol, ScVal, ScValType, ScVec,
+};
+
+// XDR contract error codes.
+pub use super::env::xdr::{
+    ScHostContextErrorCode, ScHostFnErrorCode, ScHostObjErrorCode, ScHostStorageErrorCode,
+    ScHostValErrorCode, ScUnknownErrorCode, ScVmErrorCode,
+};
+
+// XDR contract env meta types.
+pub use super::env::xdr::{ScEnvMetaEntry, ScEnvMetaKind};
+
+// XDR contract spec types.
+pub use super::env::xdr::{
+    ScSpecEntry, ScSpecEntryKind, ScSpecFunctionV0, ScSpecType, ScSpecTypeDef, ScSpecTypeMap,
+    ScSpecTypeOption, ScSpecTypeResult, ScSpecTypeSet, ScSpecTypeTuple, ScSpecTypeUdt,
+    ScSpecTypeVec, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, ScSpecUdtUnionCaseV0,
+    ScSpecUdtUnionV0,
+};


### PR DESCRIPTION
### What
Export the `xdr::HostFunction` type, but keep it hidden.

### Why
I removed it in #323, but turns out the macros use it that @jonjove is adding in #316 and current example contracts use it.

For #173