### PR TITLE
Move panic handler into the sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,11 +814,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stellar-contract-env-panic-handler-wasm32-unreachable"
-version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=3d3adbc7#3d3adbc7ff2cef7811b5269fdf44fdf1d411cc85"
-
-[[package]]
 name = "stellar-contract-macros"
 version = "0.0.0"
 dependencies = [
@@ -838,7 +833,6 @@ dependencies = [
  "hex",
  "stellar-contract-env-guest",
  "stellar-contract-env-host",
- "stellar-contract-env-panic-handler-wasm32-unreachable",
  "stellar-contract-macros",
  "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=94e01c7b)",
  "trybuild",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -13,7 +13,6 @@ stellar-contract-macros = { path = "../macros" }
 ed25519-dalek = { version = "1.0.1", optional = true }
 
 [target.'cfg(target_family="wasm")'.dependencies]
-stellar-contract-env-panic-handler-wasm32-unreachable = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "3d3adbc7" }
 stellar-contract-env-guest = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "3d3adbc7" }
 # stellar-contract-env-guest = { path = "../../rs-stellar-contract-env/stellar-contract-env-guest" }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -7,7 +7,10 @@
 //mod alloc;
 
 #[cfg(target_family = "wasm")]
-use stellar_contract_env_panic_handler_wasm32_unreachable as _;
+#[panic_handler]
+fn handle_panic(_: &core::panic::PanicInfo) -> ! {
+    core::arch::wasm32::unreachable()
+}
 
 #[cfg_attr(target_family = "wasm", link_section = "contractenvmetav0")]
 static ENV_META_XDR: [u8; env::meta::XDR.len()] = env::meta::XDR;


### PR DESCRIPTION
### What
Move the panic handler into the sdk.

### Why
Simplify release process.

For https://github.com/stellar/jump-cannon-deliverables/issues/9