### PR TITLE
Remove stellar-contract-env-panic-handler-wasm32-unreachable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,11 +814,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stellar-contract-env-panic-handler-wasm32-unreachable"
-version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=79b13dd#79b13dd98968f0cfe8faf36f3ecefab40fbc1920"
-
-[[package]]
 name = "stellar-contract-macros"
 version = "0.0.0"
 dependencies = [
@@ -838,7 +833,6 @@ dependencies = [
  "hex",
  "stellar-contract-env-guest",
  "stellar-contract-env-host",
- "stellar-contract-env-panic-handler-wasm32-unreachable",
  "stellar-contract-macros",
  "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=94e01c7b)",
  "trybuild",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -13,7 +13,6 @@ stellar-contract-macros = { path = "../macros" }
 ed25519-dalek = { version = "1.0.1", optional = true }
 
 [target.'cfg(target_family="wasm")'.dependencies]
-stellar-contract-env-panic-handler-wasm32-unreachable = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "79b13dd" }
 stellar-contract-env-guest = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "79b13dd" }
 # stellar-contract-env-guest = { path = "../../rs-stellar-contract-env/stellar-contract-env-guest" }
 


### PR DESCRIPTION
### What
Remove `stellar-contract-env-panic-handler-wasm32-unreachable`.

### Why
It was removed in #344, but then accidentally re-added in #345.